### PR TITLE
improve: remove battle eye

### DIFF
--- a/edit/edit.go
+++ b/edit/edit.go
@@ -165,10 +165,7 @@ func removeBattlEye(tibiaPath string, tibiaBinary []byte) []byte {
 	return tibiaBinary
 }
 
-func isWindowsExecutable(tibiaPath string, tibiaBinary []byte) bool {
-	if filepath.Ext(tibiaPath) == ".exe" {
-		return true
-	}
+func isWindowsExecutable(_ string, tibiaBinary []byte) bool {
 	return len(tibiaBinary) >= 2 && tibiaBinary[0] == 'M' && tibiaBinary[1] == 'Z'
 }
 

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -2,6 +2,7 @@ package edit
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -166,7 +167,19 @@ func removeBattlEye(tibiaPath string, tibiaBinary []byte) []byte {
 }
 
 func isWindowsExecutable(_ string, tibiaBinary []byte) bool {
-	return len(tibiaBinary) >= 2 && tibiaBinary[0] == 'M' && tibiaBinary[1] == 'Z'
+	if len(tibiaBinary) < 0x40 || tibiaBinary[0] != 'M' || tibiaBinary[1] != 'Z' {
+		return false
+	}
+
+	peOffset := int(binary.LittleEndian.Uint32(tibiaBinary[0x3c:0x40]))
+	if peOffset < 0 || peOffset+4 > len(tibiaBinary) {
+		return false
+	}
+
+	return tibiaBinary[peOffset] == 'P' &&
+		tibiaBinary[peOffset+1] == 'E' &&
+		tibiaBinary[peOffset+2] == 0x00 &&
+		tibiaBinary[peOffset+3] == 0x00
 }
 
 func hasAppliedBattlEyePatch(tibiaBinary []byte) bool {

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -30,8 +30,26 @@ var (
 )
 
 var paddingByte = []byte{0x20}
-var battleyeHex = []byte{0x8d, 0x4d, 0xb4, 0x75, 0x0e, 0xe8, 0xb4, 0x53}
-var removeBattleyeHex = []byte{0x8d, 0x4d, 0xb4, 0xeb, 0x0e, 0xe8, 0xb4, 0x53}
+
+type battleyePatch struct {
+	from []byte
+	to   []byte
+}
+
+var battleyePatches = []battleyePatch{
+	{
+		from: []byte{0x8d, 0x4d, 0xb4, 0x75, 0x0e, 0xe8, 0xb4, 0x53},
+		to:   []byte{0x8d, 0x4d, 0xb4, 0xeb, 0x0e, 0xe8, 0xb4, 0x53},
+	},
+	{
+		from: []byte{0x75, 0x0f, 0xe8, 0x35, 0xff, 0xff, 0xff, 0x48},
+		to:   []byte{0xeb, 0x0f, 0xe8, 0x35, 0xff, 0xff, 0xff, 0x48},
+	},
+	{
+		from: []byte{0x75, 0x0f, 0xe8, 0xd9, 0xd4, 0xed, 0xff, 0x48},
+		to:   []byte{0xeb, 0x0f, 0xe8, 0xd9, 0xd4, 0xed, 0xff, 0x48},
+	},
+}
 
 func Edit(tibiaExe string) {
 	err := viper.ReadInConfig()
@@ -65,7 +83,7 @@ func Edit(tibiaExe string) {
 	backupTibiaExecutable(tibiaPath, tibiaBinary)
 
 	tibiaBinary = replaceTibiaRSAKey(tibiaBinary)
-	tibiaBinary = removeBattlEye(tibiaBinary)
+	tibiaBinary = removeBattlEye(tibiaPath, tibiaBinary)
 
 	for prop, value := range configValues {
 		ok := setPropertyByName(tibiaBinary, prop, value)
@@ -114,20 +132,53 @@ func replaceTibiaRSAKey(tibiaBinary []byte) []byte {
 	return tibiaBinary
 }
 
-func removeBattlEye(tibiaBinary []byte) []byte {
-	fmt.Printf("[INFO] Searching for Battleye... \n")
-
-	if bytes.Contains(tibiaBinary, battleyeHex) {
-		fmt.Printf("[INFO] Battleye found!\n")
-		tibiaBinary = bytes.Replace(tibiaBinary, battleyeHex, removeBattleyeHex, 1)
-		fmt.Printf("[PATCH] Battleye removed!\n")
-	} else if bytes.Contains(tibiaBinary, removeBattleyeHex) {
-		fmt.Printf("[WARN] Battleye already removed!\n")
-	} else {
-		fmt.Printf("[WARN] Battleye not found\n")
+func removeBattlEye(tibiaPath string, tibiaBinary []byte) []byte {
+	if !isWindowsExecutable(tibiaPath, tibiaBinary) {
+		fmt.Printf("[WARN] Battleye patch skipped because the client is not a Windows executable\n")
+		return tibiaBinary
 	}
 
+	fmt.Printf("[INFO] Searching for Battleye... \n")
+
+	patchesApplied := 0
+	for _, patch := range battleyePatches {
+		count := bytes.Count(tibiaBinary, patch.from)
+		if count == 0 {
+			continue
+		}
+		tibiaBinary = bytes.ReplaceAll(tibiaBinary, patch.from, patch.to)
+		patchesApplied += count
+	}
+
+	if patchesApplied > 0 {
+		fmt.Printf("[INFO] Battleye found!\n")
+		fmt.Printf("[PATCH] Battleye removed! Applied %d patch(es)\n", patchesApplied)
+		return tibiaBinary
+	}
+
+	if hasAppliedBattlEyePatch(tibiaBinary) {
+		fmt.Printf("[WARN] Battleye already removed!\n")
+		return tibiaBinary
+	}
+
+	fmt.Printf("[WARN] Battleye not found\n")
 	return tibiaBinary
+}
+
+func isWindowsExecutable(tibiaPath string, tibiaBinary []byte) bool {
+	if filepath.Ext(tibiaPath) == ".exe" {
+		return true
+	}
+	return len(tibiaBinary) >= 2 && tibiaBinary[0] == 'M' && tibiaBinary[1] == 'Z'
+}
+
+func hasAppliedBattlEyePatch(tibiaBinary []byte) bool {
+	for _, patch := range battleyePatches {
+		if bytes.Contains(tibiaBinary, patch.to) {
+			return true
+		}
+	}
+	return false
 }
 
 func exportModifiedFile(tibiaPath string, tibiaBinary []byte, originalBinarySize int) {

--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -6,7 +6,8 @@ import (
 )
 
 func TestRemoveBattlEyeAppliesAllKnownWindowsPatches(t *testing.T) {
-	tibiaBinary := []byte("MZ--BattlEye--")
+	tibiaBinary := newPEBinary()
+	tibiaBinary = append(tibiaBinary, []byte("BattlEye--")...)
 	tibiaBinary = append(tibiaBinary, []byte{0x8d, 0x4d, 0xb4, 0x75, 0x0e, 0xe8, 0xb4, 0x53}...)
 	tibiaBinary = append(tibiaBinary, []byte{0x75, 0x0f, 0xe8, 0xd9, 0xd4, 0xed, 0xff, 0x48}...)
 	tibiaBinary = append(tibiaBinary, []byte{0x75, 0x0f, 0xe8, 0x35, 0xff, 0xff, 0xff, 0x48}...)
@@ -43,4 +44,26 @@ func TestRemoveBattlEyeSkipsNonWindowsExecutable(t *testing.T) {
 	if !bytes.Equal(patched, original) {
 		t.Fatal("expected non-Windows executable to be unchanged")
 	}
+}
+
+func TestRemoveBattlEyeSkipsMZWithoutPESignature(t *testing.T) {
+	tibiaBinary := []byte("MZ--BattlEye--")
+	tibiaBinary = append(tibiaBinary, []byte{0x75, 0x0f, 0xe8, 0x35, 0xff, 0xff, 0xff, 0x48}...)
+	original := append([]byte(nil), tibiaBinary...)
+
+	patched := removeBattlEye("client.exe", tibiaBinary)
+
+	if !bytes.Equal(patched, original) {
+		t.Fatal("expected MZ-only executable to be unchanged")
+	}
+}
+
+func newPEBinary() []byte {
+	binary := make([]byte, 0x84)
+	binary[0] = 'M'
+	binary[1] = 'Z'
+	binary[0x3c] = 0x80
+	binary[0x80] = 'P'
+	binary[0x81] = 'E'
+	return binary
 }

--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -7,16 +7,23 @@ import (
 
 func TestRemoveBattlEyeAppliesAllKnownWindowsPatches(t *testing.T) {
 	tibiaBinary := []byte("MZ--BattlEye--")
+	tibiaBinary = append(tibiaBinary, []byte{0x8d, 0x4d, 0xb4, 0x75, 0x0e, 0xe8, 0xb4, 0x53}...)
 	tibiaBinary = append(tibiaBinary, []byte{0x75, 0x0f, 0xe8, 0xd9, 0xd4, 0xed, 0xff, 0x48}...)
 	tibiaBinary = append(tibiaBinary, []byte{0x75, 0x0f, 0xe8, 0x35, 0xff, 0xff, 0xff, 0x48}...)
 
 	patched := removeBattlEye("client.exe", tibiaBinary)
 
+	if bytes.Contains(patched, []byte{0x8d, 0x4d, 0xb4, 0x75, 0x0e, 0xe8, 0xb4, 0x53}) {
+		t.Fatal("expected legacy Battleye bytes to be patched")
+	}
 	if bytes.Contains(patched, []byte{0x75, 0x0f, 0xe8, 0xd9, 0xd4, 0xed, 0xff, 0x48}) {
 		t.Fatal("expected first Battleye bytes to be patched")
 	}
 	if bytes.Contains(patched, []byte{0x75, 0x0f, 0xe8, 0x35, 0xff, 0xff, 0xff, 0x48}) {
 		t.Fatal("expected second Battleye bytes to be patched")
+	}
+	if !bytes.Contains(patched, []byte{0x8d, 0x4d, 0xb4, 0xeb, 0x0e, 0xe8, 0xb4, 0x53}) {
+		t.Fatal("expected legacy patched Battleye bytes")
 	}
 	if !bytes.Contains(patched, []byte{0xeb, 0x0f, 0xe8, 0xd9, 0xd4, 0xed, 0xff, 0x48}) {
 		t.Fatal("expected first patched Battleye bytes")
@@ -31,7 +38,7 @@ func TestRemoveBattlEyeSkipsNonWindowsExecutable(t *testing.T) {
 	tibiaBinary = append(tibiaBinary, []byte{0x75, 0x0f, 0xe8, 0x35, 0xff, 0xff, 0xff, 0x48}...)
 	original := append([]byte(nil), tibiaBinary...)
 
-	patched := removeBattlEye("client", tibiaBinary)
+	patched := removeBattlEye("client.exe", tibiaBinary)
 
 	if !bytes.Equal(patched, original) {
 		t.Fatal("expected non-Windows executable to be unchanged")

--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -1,0 +1,39 @@
+package edit
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestRemoveBattlEyeAppliesAllKnownWindowsPatches(t *testing.T) {
+	tibiaBinary := []byte("MZ--BattlEye--")
+	tibiaBinary = append(tibiaBinary, []byte{0x75, 0x0f, 0xe8, 0xd9, 0xd4, 0xed, 0xff, 0x48}...)
+	tibiaBinary = append(tibiaBinary, []byte{0x75, 0x0f, 0xe8, 0x35, 0xff, 0xff, 0xff, 0x48}...)
+
+	patched := removeBattlEye("client.exe", tibiaBinary)
+
+	if bytes.Contains(patched, []byte{0x75, 0x0f, 0xe8, 0xd9, 0xd4, 0xed, 0xff, 0x48}) {
+		t.Fatal("expected first Battleye bytes to be patched")
+	}
+	if bytes.Contains(patched, []byte{0x75, 0x0f, 0xe8, 0x35, 0xff, 0xff, 0xff, 0x48}) {
+		t.Fatal("expected second Battleye bytes to be patched")
+	}
+	if !bytes.Contains(patched, []byte{0xeb, 0x0f, 0xe8, 0xd9, 0xd4, 0xed, 0xff, 0x48}) {
+		t.Fatal("expected first patched Battleye bytes")
+	}
+	if !bytes.Contains(patched, []byte{0xeb, 0x0f, 0xe8, 0x35, 0xff, 0xff, 0xff, 0x48}) {
+		t.Fatal("expected second patched Battleye bytes")
+	}
+}
+
+func TestRemoveBattlEyeSkipsNonWindowsExecutable(t *testing.T) {
+	tibiaBinary := []byte("ELF--BattlEye--")
+	tibiaBinary = append(tibiaBinary, []byte{0x75, 0x0f, 0xe8, 0x35, 0xff, 0xff, 0xff, 0x48}...)
+	original := append([]byte(nil), tibiaBinary...)
+
+	patched := removeBattlEye("client", tibiaBinary)
+
+	if !bytes.Equal(patched, original) {
+		t.Fatal("expected non-Windows executable to be unchanged")
+	}
+}


### PR DESCRIPTION
This pull request improves the Battleye patching logic in the `edit` package by generalizing the patching mechanism, making it safer and more extensible, and adding automated tests to verify correct behavior. The main changes are the introduction of a list of Battleye patch signatures, enhanced detection and patching logic, and comprehensive unit tests.

### Battleye patching improvements

* Replaced the old single-signature Battleye patching with a new `battleyePatches` slice, allowing multiple Battleye patterns to be patched in one pass (`edit/edit.go`).
* Updated the `removeBattlEye` function to iterate over all known Battleye signatures and apply patches as needed, and improved logging to reflect how many patches were applied (`edit/edit.go`).
* Added a check to ensure Battleye patching only runs on Windows executables, skipping non-Windows binaries safely (`edit/edit.go`).

### Testing

* Added `edit/edit_test.go` with tests to verify that all known Battleye signatures are patched correctly and that non-Windows executables are not modified (`edit/edit_test.go`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced Battleye removal with multiple patch patterns for more comprehensive coverage
  * Added validation to process only Windows executables
  * Improved detection of already-applied patches with better status reporting

* **Tests**
  * Added test coverage for Battleye removal on Windows executables and non-Windows binaries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->