### PR TITLE
feat: add experimental aggressive BattlEye client-check patching

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ For a local client using [SlenderAAC](https://github.com/luan/slenderaac) you ca
 ./client-editor edit -t <tibia.exe location> -c local.toml
 ```
 
+The `edit` command also keeps the client-side `config.ini` in sync with the embedded INI block from the source client executable. The tool looks for the client default block starting at `[URLS]`, applies the TOML URL overrides that are also patched into the executable, writes to `conf/config.ini` when that client layout exists, and falls back to `config.ini` beside the executable otherwise. Existing comments and unknown sections are preserved. In sections managed by the embedded client config, outdated values are replaced, missing keys are appended, and obsolete keys that no longer exist in that client build are removed.
+
 ### Client-check safety
 
 By default, `edit` keeps the safe behavior: known stable BattlEye patches are applied, diagnostic-only high-risk signatures are reported, and high-risk client-check paths are not rewritten.

--- a/README.md
+++ b/README.md
@@ -24,15 +24,131 @@ For a local client using [SlenderAAC](https://github.com/luan/slenderaac) you ca
 ./client-editor edit -t <tibia.exe location> -c local.toml
 ```
 
+### Client-check safety
+
+By default, `edit` keeps the safe behavior: known stable BattlEye patches are applied, diagnostic-only high-risk signatures are reported, and high-risk client-check paths are not rewritten.
+
+The edit command refuses to export only when strong unsupported client-check evidence remains. If the verdict is `PARTIAL` or `WARNING` but strong evidence is `none`, the export is allowed and the tool prints warnings for manual validation.
+
+```bash
+# Windows
+.\client-editor.exe edit -t <new-client.exe> -c config.toml
+
+# Unix
+./client-editor edit -t <new-client> -c config.toml
+```
+
+Use `--strict` for CI, release scripts, or any workflow where `PARTIAL`, `WARNING`, or `UNSUPPORTED` support must stop the export:
+
+```bash
+# Windows
+.\client-editor.exe edit -t <new-client.exe> -c config.toml --strict
+
+# Unix
+./client-editor edit -t <new-client> -c config.toml --strict
+```
+
+When a pristine executable is available, pass it with `--source-exe`. If omitted, `edit` automatically uses `client - original.exe` beside `--tibia-exe` when that file exists.
+
+```bash
+# Windows
+.\client-editor.exe edit -t client.exe --source-exe "client - original.exe" -c local.toml
+
+# Unix
+./client-editor edit -t client --source-exe "client-original" -c local.toml
+```
+
+### Aggressive mode
+
+`--aggressive` enables optional rewriting of known high-risk client-check dispatch signatures that are diagnostic-only in safe mode. This mode is experimental and intended for manually validated clients only.
+
+- `--aggressive=false`: default behavior; high-risk signatures are reported but not rewritten.
+- `--aggressive=true`: rewrites the two high-risk paths and prints a large warning before patching. The `clientcheck_disconnected` path is neutralized by nopping its final dispatch call; the `enableClientCheck` xref wrapper is neutralized without changing its original tail jump.
+- `--strict --aggressive`: still fails the export when the final diagnosis is unsafe, even after aggressive rewriting.
+
+Aggressive signatures are version-scoped. If a newer or older client does not match the high-risk byte pattern exactly, the high-risk rewrite is skipped and only stable patchable signatures are applied. Every applied patch logs a before/after byte window covering the rewritten bytes.
+
+```bash
+# Windows
+.\client-editor.exe edit -t client.exe --source-exe "client - original.exe" -c local.toml --aggressive
+
+# Unix
+./client-editor edit -t client --source-exe "client-original" -c local.toml --aggressive
+```
+
+### Diagnose client-check compatibility
+
+Use `diagnose` to inspect a Tibia executable without modifying it. The report includes SHA256, file size, known BattlEye/client-check signature states, remaining client-check string indicators, nearby code references, and a support verdict.
+
+The report separates weak indicators, suspicious active candidates, high-risk diagnostic-only signatures, and strong unsupported evidence. `BEClient` is treated as weak because it often appears in Qt metadata. Critical strings become strong evidence only when the code reference also has nearby branch/call evidence and no known patch signature close to that context.
+
+Verdicts:
+
+- `SUPPORTED`: all known patchable signatures are covered and no strong evidence remains.
+- `PARTIAL`: only some known patchable signatures are covered.
+- `WARNING`: a known patch is applied, but suspicious or high-risk diagnostic evidence still remains.
+- `UNSUPPORTED`: strong client-check code evidence remains.
+
+`diagnose --strict` exits with an error for `PARTIAL`, `WARNING`, or `UNSUPPORTED`; plain `diagnose` only reports.
+
+```bash
+# Windows
+.\client-editor.exe diagnose -t <new-client.exe>
+
+# Unix
+./client-editor diagnose -t <new-client>
+```
+
+When running from a source checkout before building a binary, use `go run .` from the repository root:
+
+```bash
+# Windows
+go run . diagnose -t <new-client.exe>
+
+# Unix
+go run . diagnose -t <new-client>
+```
+
+Use strict mode in CI or release scripts when diagnostics should fail if compatibility is partial, warning, or unsupported:
+
+```bash
+# Windows
+.\client-editor.exe diagnose -t <new-client.exe> --strict
+
+# Unix
+./client-editor diagnose -t <new-client> --strict
+```
+
+For a useful old-vs-new comparison, pass a known-good older client with `--compare-with`:
+
+```bash
+# Windows, comparing original binaries before client-editor patches either file
+.\client-editor.exe diagnose -t <new-original-client.exe> --compare-with <old-original-client.exe>
+
+# Windows, same comparison through go run from the repository root
+go run . diagnose -t <new-original-client.exe> --compare-with <old-original-client.exe>
+
+# Windows, comparing already patched binaries after client-editor was run on both versions
+.\client-editor.exe diagnose -t <new-patched-client.exe> --compare-with <old-patched-client.exe>
+
+# Unix, comparing original binaries before client-editor patches either file
+./client-editor diagnose -t <new-original-client> --compare-with <old-original-client>
+
+# Unix, comparing already patched binaries after client-editor was run on both versions
+./client-editor diagnose -t <new-patched-client> --compare-with <old-patched-client>
+```
+
+The old client does not have to be original, but both sides should be in the same state. Compare original-vs-original when deciding whether a new version is supported before editing. Compare patched-vs-patched when diagnosing why a new patched client still behaves differently from an older patched client that works.
+
 ### Repack client
 
 Repack an existing tibia client for [use with slender-launcher](https://github.com/luan/slender-launcher). Repack requires a `client.<platform>.json` and `assets.<platform>.json` for each of the platforms you want to repack. Check out https://github.com/luan/tibia-client for an example.
 
 ```bash
 # Windows
-.\client-editor.exe repack -s C:\Games\Tibia-windows -d C:\Users\YourName\src\tibia-client -p windows
-.\client-editor.exe repack -s C:\Games\Tibia-mac -d C:\Users\YourName\src\tibia-client -p mac
-.\client-editor.exe repack -s C:\Games\Tibia-linux -d C:\Users\YourName\src\tibia-client -p linux
+.\client-editor.exe repack -s <Tibia-windows folder> -d <tibia-client output folder> -p windows
+.\client-editor.exe repack -s <Tibia-mac folder> -d <tibia-client output folder> -p mac
+.\client-editor.exe repack -s <Tibia-linux folder> -d <tibia-client output folder> -p linux
 
 # Unix
 ./client-editor repack -s ~/Games/Tibia-windows -d ~/src/tibia-client -p windows

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -42,6 +42,9 @@ const (
 	contextBytesRadius      = 48
 	knownPatchContextRadius = 512
 	patchContextRadius      = 32
+	configINIFileName       = "config.ini"
+	configINIDirName        = "conf"
+	configINIStartMarker    = "[URLS]"
 )
 
 type battleyePatch struct {
@@ -315,8 +318,20 @@ func Edit(tibiaExe string, sourceTibiaExe string, strictClientCheck bool, aggres
 		}
 	}
 
-	backupTibiaExecutable(tibiaPath, originalTibiaBinary, aggressiveClientCheck)
+	backupBinary := originalTibiaBinary
+	if sourcePath != tibiaExe {
+		targetBinary, err := os.ReadFile(tibiaPath)
+		if err == nil {
+			backupBinary = targetBinary
+		} else if !os.IsNotExist(err) {
+			fmt.Printf("[ERROR] Unable to read target executable for backup: %s\n", err.Error())
+			os.Exit(1)
+		}
+	}
+
+	backupTibiaExecutable(tibiaPath, backupBinary, aggressiveClientCheck)
 	exportModifiedFile(tibiaPath, tibiaBinary, originalBinarySize)
+	syncConfigINI(tibiaPath, originalTibiaBinary, configValues)
 	logEditSuccess(diagnosis, strictClientCheck)
 }
 
@@ -526,12 +541,13 @@ func isWindowsExecutable(_ string, tibiaBinary []byte) bool {
 
 func analyzeTibiaBinary(tibiaPath string, tibiaBinary []byte) diagnosisReport {
 	sum := sha256.Sum256(tibiaBinary)
+	sha256Text := fmt.Sprintf("%x", sum[:])
 	diagnosis := diagnosisReport{
 		path:          tibiaPath,
 		size:          len(tibiaBinary),
-		sha256:        fmt.Sprintf("%x", sum[:]),
+		sha256:        sha256Text,
 		isWindowsExe:  isWindowsExecutable(tibiaPath, tibiaBinary),
-		patchStatuses: scanBattlEyePatchStatus(tibiaBinary),
+		patchStatuses: scanBattlEyePatchStatus(tibiaBinary, sha256Text),
 	}
 
 	if diagnosis.isWindowsExe {
@@ -543,9 +559,7 @@ func analyzeTibiaBinary(tibiaPath string, tibiaBinary []byte) diagnosisReport {
 	return diagnosis
 }
 
-func scanBattlEyePatchStatus(tibiaBinary []byte) []battleyePatchStatus {
-	sum := sha256.Sum256(tibiaBinary)
-	sha256Text := fmt.Sprintf("%x", sum[:])
+func scanBattlEyePatchStatus(tibiaBinary []byte, sha256Text string) []battleyePatchStatus {
 	statuses := make([]battleyePatchStatus, 0, len(battleyePatches))
 	for _, patch := range battleyePatches {
 		patchedOffsets := patch.patched.findAll(tibiaBinary)
@@ -581,7 +595,7 @@ func inspectPE(tibiaBinary []byte) peInfo {
 	for _, section := range peFile.Sections {
 		rawStart := int(section.Offset)
 		rawEnd := rawStart + int(section.Size)
-		if rawStart > len(tibiaBinary) {
+		if rawStart < 0 || rawEnd < 0 || rawStart > len(tibiaBinary) {
 			continue
 		}
 		if rawEnd > len(tibiaBinary) {
@@ -1946,16 +1960,355 @@ func neutralizeBranchJumpPattern(pattern bytePattern, patch map[int]int) []int {
 
 	for index, value := range patch {
 		if index < 0 || index >= len(replacement) {
-			fmt.Printf("[ERROR] Invalid branch neutralization offset %d for pattern %d bytes\n", index, len(replacement))
-			os.Exit(1)
+			panic(fmt.Sprintf("invalid branch neutralization offset %d for pattern %d bytes", index, len(replacement)))
 		}
 		if value < 0 || value > 0xff {
-			fmt.Printf("[ERROR] Invalid branch neutralization byte %d at position %d\n", value, index)
-			os.Exit(1)
+			panic(fmt.Sprintf("invalid branch neutralization byte %d at position %d", value, index))
 		}
 		replacement[index] = value
 	}
 	return replacement
+}
+
+type configINIKeyValue struct {
+	key   string
+	value string
+}
+
+type configINISection struct {
+	name      string
+	keys      []configINIKeyValue
+	keyValues map[string]string
+}
+
+type embeddedConfigINI struct {
+	sections      []configINISection
+	sectionByName map[string]configINISection
+}
+
+func syncConfigINI(tibiaPath string, tibiaBinary []byte, configValues map[string]string) {
+	embeddedConfigData, ok := extractEmbeddedConfigINIBlock(tibiaBinary)
+	if !ok {
+		fmt.Printf("[WARN] Embedded config.ini block starting at %q was not found; %s sync skipped\n", configINIStartMarker, configINIFileName)
+		return
+	}
+
+	embeddedConfig, ok := parseEmbeddedConfigINI(embeddedConfigData)
+	if !ok {
+		fmt.Printf("[WARN] Embedded config.ini block could not be parsed; %s sync skipped\n", configINIFileName)
+		return
+	}
+	embeddedConfig = overrideEmbeddedConfigValues(embeddedConfig, configValues)
+
+	configPath, configExists := resolveConfigINIPath(tibiaPath)
+	configData := make([]byte, 0)
+	if configExists {
+		data, err := os.ReadFile(configPath)
+		if err != nil {
+			fmt.Printf("[ERROR] Unable to read %s: %s\n", configPath, err.Error())
+			os.Exit(1)
+		}
+		configData = data
+	}
+
+	updatedConfig, changedCount, addedCount, removedCount, changed := updateConfigINIContent(configData, embeddedConfig)
+	if !changed {
+		fmt.Printf("[INFO] %s already up to date\n", configINIFileName)
+		return
+	}
+
+	if err := os.WriteFile(configPath, updatedConfig, 0644); err != nil {
+		fmt.Printf("[ERROR] Unable to write %s: %s\n", configPath, err.Error())
+		os.Exit(1)
+	}
+
+	if configExists {
+		fmt.Printf("[PATCH] %s updated from embedded client config (%d outdated value(s), %d new key(s), %d obsolete key(s) removed)\n", configINIFileName, changedCount, addedCount, removedCount)
+		return
+	}
+	fmt.Printf("[PATCH] %s created from embedded client config (%d key(s))\n", configINIFileName, addedCount)
+}
+
+func resolveConfigINIPath(tibiaPath string) (string, bool) {
+	tibiaDir := filepath.Dir(tibiaPath)
+	confConfigPath := filepath.Clean(filepath.Join(tibiaDir, "..", configINIDirName, configINIFileName))
+	binConfigPath := filepath.Join(tibiaDir, configINIFileName)
+
+	for _, candidate := range []string{confConfigPath, binConfigPath} {
+		info, err := os.Stat(candidate)
+		if err == nil && !info.IsDir() {
+			return candidate, true
+		}
+	}
+
+	confDir := filepath.Dir(confConfigPath)
+	if info, err := os.Stat(confDir); err == nil && info.IsDir() {
+		return confConfigPath, false
+	}
+
+	return binConfigPath, false
+}
+
+func extractEmbeddedConfigINIBlock(tibiaBinary []byte) ([]byte, bool) {
+	start := bytes.Index(tibiaBinary, []byte(configINIStartMarker))
+	if start == -1 {
+		return nil, false
+	}
+
+	end := start
+	for end < len(tibiaBinary) {
+		value := tibiaBinary[end]
+		if value == 0 {
+			break
+		}
+		if value == '\r' || value == '\n' || value == '\t' || (value >= 0x20 && value <= 0x7e) {
+			end++
+			continue
+		}
+		break
+	}
+
+	if end <= start {
+		return nil, false
+	}
+	return tibiaBinary[start:end], true
+}
+
+func parseEmbeddedConfigINI(configData []byte) (embeddedConfigINI, bool) {
+	config := embeddedConfigINI{}
+	currentSectionIndex := -1
+	for _, line := range splitConfigINILines(configData) {
+		if sectionName, ok := parseConfigINISectionLine(line); ok {
+			config.sections = append(config.sections, configINISection{
+				name:      sectionName,
+				keyValues: make(map[string]string),
+			})
+			currentSectionIndex = len(config.sections) - 1
+			continue
+		}
+
+		if currentSectionIndex == -1 {
+			continue
+		}
+
+		key, value, ok := splitConfigINILine(line)
+		if !ok {
+			continue
+		}
+
+		section := &config.sections[currentSectionIndex]
+		if _, exists := section.keyValues[key]; exists {
+			continue
+		}
+		section.keys = append(section.keys, configINIKeyValue{key: key, value: value})
+		section.keyValues[key] = value
+	}
+
+	totalKeys := 0
+	config.sectionByName = make(map[string]configINISection, len(config.sections))
+	for _, section := range config.sections {
+		config.sectionByName[section.name] = section
+		totalKeys += len(section.keys)
+	}
+
+	return config, totalKeys > 0
+}
+
+func overrideEmbeddedConfigValues(embeddedConfig embeddedConfigINI, configValues map[string]string) embeddedConfigINI {
+	for sectionIndex := range embeddedConfig.sections {
+		section := &embeddedConfig.sections[sectionIndex]
+		for keyIndex := range section.keys {
+			value, ok := configValues[section.keys[keyIndex].key]
+			if !ok {
+				continue
+			}
+
+			section.keys[keyIndex].value = value
+			section.keyValues[section.keys[keyIndex].key] = value
+		}
+	}
+
+	embeddedConfig.sectionByName = make(map[string]configINISection, len(embeddedConfig.sections))
+	for _, section := range embeddedConfig.sections {
+		embeddedConfig.sectionByName[section.name] = section
+	}
+	return embeddedConfig
+}
+
+func updateConfigINIContent(configData []byte, embeddedConfig embeddedConfigINI) ([]byte, int, int, int, bool) {
+	lineEnding := detectLineEnding(configData)
+	if len(configData) == 0 {
+		return renderEmbeddedConfigINI(embeddedConfig, lineEnding), 0, embeddedConfigKeyCount(embeddedConfig), 0, true
+	}
+
+	lines := splitConfigINILines(configData)
+	output := make([]string, 0, len(lines)+embeddedConfigKeyCount(embeddedConfig))
+	seenSections := make(map[string]struct{}, len(embeddedConfig.sections))
+	seenKeys := make(map[string]map[string]struct{}, len(embeddedConfig.sections))
+	changedCount := 0
+	addedCount := 0
+	removedCount := 0
+	currentSection := ""
+	currentManaged := false
+
+	appendMissingKeys := func(sectionName string) {
+		section, ok := embeddedConfig.sectionByName[sectionName]
+		if !ok {
+			return
+		}
+		if _, ok := seenKeys[sectionName]; !ok {
+			seenKeys[sectionName] = make(map[string]struct{}, len(section.keys))
+		}
+		for _, item := range section.keys {
+			if _, ok := seenKeys[sectionName][item.key]; ok {
+				continue
+			}
+			output = append(output, item.key+"="+item.value)
+			seenKeys[sectionName][item.key] = struct{}{}
+			addedCount++
+		}
+	}
+
+	for _, line := range lines {
+		if sectionName, ok := parseConfigINISectionLine(line); ok {
+			if currentManaged {
+				appendMissingKeys(currentSection)
+			}
+
+			currentSection = sectionName
+			_, currentManaged = embeddedConfig.sectionByName[currentSection]
+			if currentManaged {
+				seenSections[currentSection] = struct{}{}
+				if _, ok := seenKeys[currentSection]; !ok {
+					seenKeys[currentSection] = make(map[string]struct{})
+				}
+			}
+
+			output = append(output, line)
+			continue
+		}
+
+		if currentManaged {
+			key, _, ok := splitConfigINILine(line)
+			if ok {
+				section := embeddedConfig.sectionByName[currentSection]
+				value, exists := section.keyValues[key]
+				if !exists {
+					removedCount++
+					continue
+				}
+				if _, duplicate := seenKeys[currentSection][key]; duplicate {
+					removedCount++
+					continue
+				}
+
+				seenKeys[currentSection][key] = struct{}{}
+				nextLine := key + "=" + value
+				if line != nextLine {
+					output = append(output, nextLine)
+					changedCount++
+					continue
+				}
+			}
+		}
+
+		output = append(output, line)
+	}
+
+	if currentManaged {
+		appendMissingKeys(currentSection)
+	}
+
+	for _, section := range embeddedConfig.sections {
+		if _, ok := seenSections[section.name]; ok {
+			continue
+		}
+		if len(output) > 0 && strings.TrimSpace(output[len(output)-1]) != "" {
+			output = append(output, "")
+		}
+		output = append(output, "["+section.name+"]")
+		for _, item := range section.keys {
+			output = append(output, item.key+"="+item.value)
+			addedCount++
+		}
+	}
+
+	if changedCount == 0 && addedCount == 0 && removedCount == 0 {
+		return configData, 0, 0, 0, false
+	}
+
+	return []byte(strings.Join(output, lineEnding) + lineEnding), changedCount, addedCount, removedCount, true
+}
+
+func splitConfigINILines(configData []byte) []string {
+	normalized := strings.ReplaceAll(string(configData), "\r\n", "\n")
+	normalized = strings.TrimRight(normalized, "\x00")
+	normalized = strings.TrimSuffix(normalized, "\n")
+	if normalized == "" {
+		return nil
+	}
+	return strings.Split(normalized, "\n")
+}
+
+func parseConfigINISectionLine(line string) (string, bool) {
+	trimmed := strings.TrimSpace(line)
+	if len(trimmed) < 3 || !strings.HasPrefix(trimmed, "[") || !strings.HasSuffix(trimmed, "]") {
+		return "", false
+	}
+
+	sectionName := strings.TrimSpace(trimmed[1 : len(trimmed)-1])
+	if sectionName == "" {
+		return "", false
+	}
+	return sectionName, true
+}
+
+func renderEmbeddedConfigINI(embeddedConfig embeddedConfigINI, lineEnding string) []byte {
+	lines := make([]string, 0, embeddedConfigKeyCount(embeddedConfig)+len(embeddedConfig.sections)*2)
+	for index, section := range embeddedConfig.sections {
+		if index > 0 {
+			lines = append(lines, "")
+		}
+		lines = append(lines, "["+section.name+"]")
+		for _, item := range section.keys {
+			lines = append(lines, item.key+"="+item.value)
+		}
+	}
+	return []byte(strings.Join(lines, lineEnding) + lineEnding)
+}
+
+func embeddedConfigKeyCount(embeddedConfig embeddedConfigINI) int {
+	total := 0
+	for _, section := range embeddedConfig.sections {
+		total += len(section.keys)
+	}
+	return total
+}
+
+func splitConfigINILine(line string) (string, string, bool) {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, ";") {
+		return "", "", false
+	}
+
+	separator := strings.Index(trimmed, "=")
+	if separator <= 0 {
+		return "", "", false
+	}
+
+	key := strings.TrimSpace(trimmed[:separator])
+	value := strings.TrimSpace(trimmed[separator+1:])
+	if key == "" {
+		return "", "", false
+	}
+	return key, value, true
+}
+
+func detectLineEnding(data []byte) string {
+	if bytes.Contains(data, []byte("\r\n")) {
+		return "\r\n"
+	}
+	return "\n"
 }
 
 func setPropertyByName(tibiaBinary []byte, propertyName string, customValue string) bool {

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -2,10 +2,14 @@ package edit
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"debug/pe"
 	"encoding/binary"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/spf13/viper"
@@ -32,27 +36,235 @@ var (
 
 var paddingByte = []byte{0x20}
 
+const (
+	wildcardByte            = -1
+	codeContextRadius       = 200
+	contextBytesRadius      = 48
+	knownPatchContextRadius = 512
+	patchContextRadius      = 32
+)
+
 type battleyePatch struct {
-	from []byte
-	to   []byte
+	name                  string
+	original              bytePattern
+	patched               bytePattern
+	replacement           []int
+	diagnosticOnly        bool
+	aggressiveReplacement []int
+	highRiskClientCheck   bool
+	expectedOffsets       []knownPatchOffset
+	falsePositiveCheck    string
+}
+
+type bytePattern struct {
+	name string
+	data []byte
+	mask []bool
+}
+
+type knownPatchOffset struct {
+	sha256 string
+	offset int
+	note   string
+}
+
+type clientCheckIndicator struct {
+	name  string
+	value []byte
+}
+
+type battleyePatchStatus struct {
+	patch                battleyePatch
+	originalOffset       []int
+	patchedOffset        []int
+	expectedOffsetHits   []knownPatchOffset
+	expectedOffsetMisses []knownPatchOffset
+}
+
+type peSectionInfo struct {
+	name     string
+	rawStart int
+	rawEnd   int
+	rvaStart int
+	rvaEnd   int
+	isCode   bool
+}
+
+type peInfo struct {
+	valid     bool
+	errorText string
+	imageBase uint64
+	sections  []peSectionInfo
+	imports   []string
+}
+
+type clientCheckReference struct {
+	offset            int
+	section           string
+	instruction       string
+	branchOffsets     []int
+	callOffsets       []int
+	contextStart      int
+	patternMatches    []patternMatch
+	contextBytes      []byte
+	knownPatchNearby  bool
+	strongUnsupported bool
+	suspiciousActive  bool
+}
+
+type patternMatch struct {
+	name   string
+	offset int
+}
+
+type clientCheckFinding struct {
+	name       string
+	encoding   string
+	offsets    []int
+	references []clientCheckReference
+}
+
+type diagnosisReport struct {
+	path                string
+	size                int
+	sha256              string
+	isWindowsExe        bool
+	pe                  peInfo
+	patchStatuses       []battleyePatchStatus
+	clientCheckFindings []clientCheckFinding
+	qtIndicators        []string
 }
 
 var battleyePatches = []battleyePatch{
 	{
-		from: []byte{0x8d, 0x4d, 0xb4, 0x75, 0x0e, 0xe8, 0xb4, 0x53},
-		to:   []byte{0x8d, 0x4d, 0xb4, 0xeb, 0x0e, 0xe8, 0xb4, 0x53},
+		name:        "legacy launch check",
+		original:    newBytePattern("legacy launch check original", 0x8d, 0x4d, 0xb4, 0x75, 0x0e, 0xe8, 0xb4, 0x53),
+		patched:     newBytePattern("legacy launch check patched", 0x8d, 0x4d, 0xb4, 0xeb, 0x0e, 0xe8, 0xb4, 0x53),
+		replacement: newPatchReplacement(0x8d, 0x4d, 0xb4, 0xeb, 0x0e, 0xe8, 0xb4, 0x53),
 	},
 	{
-		from: []byte{0x75, 0x0f, 0xe8, 0x35, 0xff, 0xff, 0xff, 0x48},
-		to:   []byte{0xeb, 0x0f, 0xe8, 0x35, 0xff, 0xff, 0xff, 0x48},
+		name:        "client check branch",
+		original:    newBytePattern("client check branch original", 0x75, 0x0f, 0xe8, 0x35, 0xff, 0xff, 0xff, 0x48),
+		patched:     newBytePattern("client check branch patched", 0xeb, 0x0f, 0xe8, 0x35, 0xff, 0xff, 0xff, 0x48),
+		replacement: newPatchReplacement(0xeb, 0x0f, 0xe8, 0x35, 0xff, 0xff, 0xff, 0x48),
+		expectedOffsets: []knownPatchOffset{
+			{
+				sha256: "c930bd29b76cec5d88d35e24dbee0ed0edaeba68bd7961c68856912c40d8728f",
+				offset: 0x2DE804,
+				note:   "reported new client; this is the only currently observed matching legacy patch point",
+			},
+		},
 	},
 	{
-		from: []byte{0x75, 0x0f, 0xe8, 0xd9, 0xd4, 0xed, 0xff, 0x48},
-		to:   []byte{0xeb, 0x0f, 0xe8, 0xd9, 0xd4, 0xed, 0xff, 0x48},
+		name:        "legacy client check branch",
+		original:    newBytePattern("legacy client check branch original", 0x75, 0x0f, 0xe8, 0xd9, 0xd4, 0xed, 0xff, 0x48),
+		patched:     newBytePattern("legacy client check branch patched", 0xeb, 0x0f, 0xe8, 0xd9, 0xd4, 0xed, 0xff, 0x48),
+		replacement: newPatchReplacement(0xeb, 0x0f, 0xe8, 0xd9, 0xd4, 0xed, 0xff, 0x48),
+	},
+	{
+		name:           "candidate client check conditional branch with variable call",
+		original:       newBytePattern("candidate client check conditional branch original", 0x75, 0x0f, 0xe8, wildcardByte, wildcardByte, wildcardByte, wildcardByte, 0x48),
+		patched:        newBytePattern("candidate client check conditional branch patched", 0xeb, 0x0f, 0xe8, wildcardByte, wildcardByte, wildcardByte, wildcardByte, 0x48),
+		replacement:    newPatchReplacement(0xeb, 0x0f, 0xe8, wildcardByte, wildcardByte, wildcardByte, wildcardByte, 0x48),
+		diagnosticOnly: true,
+		expectedOffsets: []knownPatchOffset{
+			{
+				sha256: "c930bd29b76cec5d88d35e24dbee0ed0edaeba68bd7961c68856912c40d8728f",
+				offset: 0x2DE804,
+				note:   "wildcard diagnostic around the reported new-client match; not auto-applied without surrounding-code review",
+			},
+		},
+		falsePositiveCheck: "diagnostic-only because the CALL rel32 bytes are wildcarded; require unique match, nearby client-check xref, and manual code-context review before making this patchable",
+	},
+	{
+		name:           "candidate clientcheck_disconnected Qt xref dispatch",
+		original:       newBytePattern("candidate clientcheck_disconnected Qt xref dispatch", 0x41, 0xb8, 0xff, 0xff, 0xff, 0xff, 0x48, 0x8d, 0x15, 0x18, 0x39, 0x80, 0x01, 0x48, 0x8d, 0x4d, 0x37, 0xff, 0x15, wildcardByte, wildcardByte, wildcardByte, wildcardByte),
+		diagnosticOnly: true,
+		expectedOffsets: []knownPatchOffset{
+			{sha256: "c930bd29b76cec5d88d35e24dbee0ed0edaeba68bd7961c68856912c40d8728f", offset: 0x1A8E5B, note: "reported new-client clientcheck_disconnected xref context"},
+			{sha256: "985fb4e114b3156a5488b7b35ed5d8615d58fff140a04d8e73c18ac0b4d871e5", offset: 0x1A8E5B, note: "observed local clientcheck_disconnected xref context"},
+		},
+		falsePositiveCheck: "diagnostic-only xref context observed around reported ref 0x1A8E61; exact displacement bytes keep this version-specific until the RIP target and branch/call flow are manually reviewed",
+	},
+	{
+		name:           "candidate BEClient Qt xref dispatch",
+		original:       newBytePattern("candidate BEClient Qt xref dispatch", 0x48, 0x8b, 0x01, 0x48, 0x8b, 0x58, 0x28, 0x48, 0x8d, 0x15, 0x45, 0x1a, 0x7f, 0x01, 0x48, 0x8d, 0x4c, 0x24, 0x28, 0xff, 0x15, wildcardByte, wildcardByte, wildcardByte, wildcardByte),
+		diagnosticOnly: true,
+		expectedOffsets: []knownPatchOffset{
+			{sha256: "c930bd29b76cec5d88d35e24dbee0ed0edaeba68bd7961c68856912c40d8728f", offset: 0x1BB425, note: "reported new-client BEClient xref context"},
+			{sha256: "985fb4e114b3156a5488b7b35ed5d8615d58fff140a04d8e73c18ac0b4d871e5", offset: 0x1BB425, note: "observed local BEClient xref context"},
+		},
+		falsePositiveCheck: "diagnostic-only xref context observed around reported ref 0x1BB42C; BEClient remains weak by itself because Qt metadata/dialog text can reference it without proving active client-check flow",
+	},
+	{
+		name:                "high-risk clientcheck_disconnected dispatch path",
+		original:            newBytePattern("high-risk clientcheck_disconnected dispatch path", 0x48, 0x83, 0x45, 0x9f, 0x48, 0xeb, 0x10, 0x4c, 0x8d, 0x45, 0xb7, 0x48, 0x8b, 0xd3, 0x48, 0x8d, 0x4d, 0x97, 0xe8, wildcardByte, wildcardByte, wildcardByte, wildcardByte, 0x48, 0x8b, 0xbf, 0x30, 0x0a, 0x00, 0x00, 0x41, 0xb8, 0xff, 0xff, 0xff, 0xff, 0x48, 0x8d, 0x15, 0x18, 0x39, 0x80, 0x01, 0x48, 0x8d, 0x4d, 0x37, 0xff, 0x15, wildcardByte, wildcardByte, wildcardByte, wildcardByte, 0x48, 0x8b, 0xd8, 0x41, 0xb8, 0xff, 0xff, 0xff, 0xff, 0x48, 0x8d, 0x15, 0xbe, 0x4a, 0x7d, 0x01, 0x48, 0x8d, 0x4d, 0x1f, 0xff, 0x15, wildcardByte, wildcardByte, wildcardByte, wildcardByte, 0x90, 0x4c, 0x8d, 0x4d, 0x97, 0x4c, 0x8b, 0xc3, 0x48, 0x8b, 0xd0, 0x48, 0x8b, 0xcf, 0xe8, wildcardByte, wildcardByte, wildcardByte, wildcardByte, 0x90),
+		diagnosticOnly:      true,
+		highRiskClientCheck: true,
+		aggressiveReplacement: neutralizeBranchJumpPattern(
+			newBytePattern("high-risk clientcheck_disconnected dispatch path [aggressive source]", 0x48, 0x83, 0x45, 0x9f, 0x48, 0xeb, 0x10, 0x4c, 0x8d, 0x45, 0xb7, 0x48, 0x8b, 0xd3, 0x48, 0x8d, 0x4d, 0x97, 0xe8, wildcardByte, wildcardByte, wildcardByte, wildcardByte, 0x48, 0x8b, 0xbf, 0x30, 0x0a, 0x00, 0x00, 0x41, 0xb8, 0xff, 0xff, 0xff, 0xff, 0x48, 0x8d, 0x15, 0x18, 0x39, 0x80, 0x01, 0x48, 0x8d, 0x4d, 0x37, 0xff, 0x15, wildcardByte, wildcardByte, wildcardByte, wildcardByte, 0x48, 0x8b, 0xd8, 0x41, 0xb8, 0xff, 0xff, 0xff, 0xff, 0x48, 0x8d, 0x15, 0xbe, 0x4a, 0x7d, 0x01, 0x48, 0x8d, 0x4d, 0x1f, 0xff, 0x15, wildcardByte, wildcardByte, wildcardByte, wildcardByte, 0x90, 0x4c, 0x8d, 0x4d, 0x97, 0x4c, 0x8b, 0xc3, 0x48, 0x8b, 0xd0, 0x48, 0x8b, 0xcf, 0xe8, wildcardByte, wildcardByte, wildcardByte, wildcardByte, 0x90),
+			map[int]int{93: 0x90, 94: 0x90, 95: 0x90, 96: 0x90, 97: 0x90},
+		),
+		expectedOffsets: []knownPatchOffset{
+			{sha256: "c930bd29b76cec5d88d35e24dbee0ed0edaeba68bd7961c68856912c40d8728f", offset: 0x1A8E3D, note: "high-risk clientcheck_disconnected dispatch path seen after the known 0x2DE804 patch"},
+			{sha256: "985fb4e114b3156a5488b7b35ed5d8615d58fff140a04d8e73c18ac0b4d871e5", offset: 0x1A8E3D, note: "observed local clientcheck_disconnected dispatch path seen after the known 0x2DE804 patch"},
+		},
+		falsePositiveCheck: "diagnostic-only high-risk path; CALL bytes are wildcarded, but fixed surrounding xref/field-access bytes tie it to the reported clientcheck_disconnected dispatch context; aggressive mode nops the final signal dispatch call",
+	},
+	{
+		name:           "candidate enableClientCheck Qt xref dispatch",
+		original:       newBytePattern("candidate enableClientCheck Qt xref dispatch", 0x48, 0x83, 0xec, 0x28, 0x48, 0x8d, 0x15, 0x65, 0xc5, 0x99, 0x01, 0x48, 0x8d, 0x0d, 0x36, 0x04, 0xcf, 0x01, 0xff, 0x15, wildcardByte, wildcardByte, wildcardByte, wildcardByte, 0x48, 0x8d, 0x0d, 0x11, 0xd0, 0xf7, 0x00),
+		diagnosticOnly: true,
+		expectedOffsets: []knownPatchOffset{
+			{sha256: "c930bd29b76cec5d88d35e24dbee0ed0edaeba68bd7961c68856912c40d8728f", offset: 0xE8C0, note: "reported new-client enableClientCheck xref context"},
+			{sha256: "985fb4e114b3156a5488b7b35ed5d8615d58fff140a04d8e73c18ac0b4d871e5", offset: 0xE8C0, note: "observed local enableClientCheck xref context"},
+		},
+		falsePositiveCheck: "diagnostic-only xref context observed around reported ref 0xE8C4; exact displacement bytes keep this version-specific until the RIP target and branch/call flow are manually reviewed",
+	},
+	{
+		name:                "high-risk enableClientCheck dispatch path",
+		original:            newBytePattern("high-risk enableClientCheck dispatch path", 0x48, 0x83, 0xec, 0x28, 0x48, 0x8d, 0x15, 0x65, 0xc5, 0x99, 0x01, 0x48, 0x8d, 0x0d, 0x36, 0x04, 0xcf, 0x01, 0xff, 0x15, wildcardByte, wildcardByte, wildcardByte, wildcardByte, 0x48, 0x8d, 0x0d, 0x11, 0xd0, 0xf7, 0x00, 0x48, 0x83, 0xc4, 0x28, wildcardByte, wildcardByte, wildcardByte, wildcardByte, wildcardByte, wildcardByte, wildcardByte, wildcardByte, wildcardByte),
+		diagnosticOnly:      true,
+		highRiskClientCheck: true,
+		aggressiveReplacement: neutralizeBranchJumpPattern(
+			newBytePattern("high-risk enableClientCheck dispatch path [aggressive source]", 0x48, 0x83, 0xec, 0x28, 0x48, 0x8d, 0x15, 0x65, 0xc5, 0x99, 0x01, 0x48, 0x8d, 0x0d, 0x36, 0x04, 0xcf, 0x01, 0xff, 0x15, wildcardByte, wildcardByte, wildcardByte, wildcardByte, 0x48, 0x8d, 0x0d, 0x11, 0xd0, 0xf7, 0x00, 0x48, 0x83, 0xc4, 0x28, wildcardByte, wildcardByte, wildcardByte, wildcardByte, wildcardByte, wildcardByte, wildcardByte, wildcardByte, wildcardByte),
+			map[int]int{18: 0x90, 19: 0x90, 20: 0x90, 21: 0x90, 22: 0x90, 23: 0x90},
+		),
+		expectedOffsets: []knownPatchOffset{
+			{sha256: "c930bd29b76cec5d88d35e24dbee0ed0edaeba68bd7961c68856912c40d8728f", offset: 0xE8C0, note: "high-risk enableClientCheck dispatch path seen after the known 0x2DE804 patch"},
+			{sha256: "985fb4e114b3156a5488b7b35ed5d8615d58fff140a04d8e73c18ac0b4d871e5", offset: 0xE8C0, note: "observed local enableClientCheck dispatch path seen after the known 0x2DE804 patch"},
+		},
+		falsePositiveCheck: "diagnostic-only high-risk path; CALL/JMP bytes are wildcarded, but fixed enableClientCheck xref and thunk shape keep the match scoped to the reported dispatch context; aggressive mode nops only the Qt metadata call and preserves the original tail jump",
 	},
 }
 
-func Edit(tibiaExe string) {
+var clientCheckIndicators = []clientCheckIndicator{
+	{name: "BEClient", value: []byte("BEClient")},
+	{name: "clientcheck_disconnected", value: []byte("clientcheck_disconnected")},
+	{name: "requestCloseDueToClientCheck", value: []byte("requestCloseDueToClientCheck")},
+	{name: "onCloseDueToClientCheckRequested", value: []byte("onCloseDueToClientCheckRequested")},
+	{name: "onClientCheckDialogButtonClicked", value: []byte("onClientCheckDialogButtonClicked")},
+	{name: "enableClientCheck", value: []byte("enableClientCheck")},
+}
+
+var clientCheckCodePatterns = []bytePattern{
+	newBytePattern("short JNE followed by CALL", 0x75, wildcardByte, 0xe8, wildcardByte, wildcardByte, wildcardByte, wildcardByte),
+	newBytePattern("short JE followed by CALL", 0x74, wildcardByte, 0xe8, wildcardByte, wildcardByte, wildcardByte, wildcardByte),
+	newBytePattern("near JNE followed by CALL", 0x0f, 0x85, wildcardByte, wildcardByte, wildcardByte, wildcardByte, 0xe8, wildcardByte, wildcardByte, wildcardByte, wildcardByte),
+	newBytePattern("near JE followed by CALL", 0x0f, 0x84, wildcardByte, wildcardByte, wildcardByte, wildcardByte, 0xe8, wildcardByte, wildcardByte, wildcardByte, wildcardByte),
+}
+
+var qtContextIndicators = []string{
+	"Qt5Core",
+	"Qt6Core",
+	"QMetaObject",
+	"QObject",
+	"qt_metacall",
+	"qt_static_metacall",
+	"QMessageBox",
+}
+
+func Edit(tibiaExe string, sourceTibiaExe string, strictClientCheck bool, aggressiveClientCheck bool) {
 	err := viper.ReadInConfig()
 	if err != nil {
 		fmt.Printf("[ERROR] Failed to read config file: %s\n", err.Error())
@@ -78,13 +290,23 @@ func Edit(tibiaExe string) {
 		configValues[prop] = value
 	}
 
-	tibiaPath, tibiaBinary := readFile(tibiaExe)
-	originalBinarySize := len(tibiaBinary)
+	tibiaPath := tibiaExe
+	sourcePath := resolveSourceExecutable(tibiaPath, sourceTibiaExe)
+	_, sourceBinary := readFile(sourcePath)
+	tibiaBinary := append([]byte(nil), sourceBinary...)
+	originalBinarySize := len(sourceBinary)
+	originalTibiaBinary := append([]byte(nil), tibiaBinary...)
 
-	backupTibiaExecutable(tibiaPath, tibiaBinary)
+	if sourcePath != tibiaExe {
+		fmt.Printf("[INFO] Using source client executable for patch input: %s\n", filepath.Base(sourcePath))
+		fmt.Printf("[INFO] Writing patched client to target executable: %s\n", filepath.Base(tibiaExe))
+	}
 
 	tibiaBinary = replaceTibiaRSAKey(tibiaBinary)
-	tibiaBinary = removeBattlEye(tibiaPath, tibiaBinary)
+	tibiaBinary = removeBattlEye(tibiaPath, tibiaBinary, aggressiveClientCheck)
+	diagnosis := analyzeTibiaBinary(tibiaPath, tibiaBinary)
+	logClientCheckSupportSummary(diagnosis)
+	enforceEditClientCheckPolicy(diagnosis, strictClientCheck)
 
 	for prop, value := range configValues {
 		ok := setPropertyByName(tibiaBinary, prop, value)
@@ -93,13 +315,41 @@ func Edit(tibiaExe string) {
 		}
 	}
 
+	backupTibiaExecutable(tibiaPath, originalTibiaBinary, aggressiveClientCheck)
 	exportModifiedFile(tibiaPath, tibiaBinary, originalBinarySize)
+	logEditSuccess(diagnosis, strictClientCheck)
 }
 
-func backupTibiaExecutable(tibiaPath string, tibiaBinary []byte) {
+func Diagnose(tibiaExe string, compareWith string, strictClientCheck bool) {
+	tibiaPath, tibiaBinary := readFile(tibiaExe)
+	diagnosis := analyzeTibiaBinary(tibiaPath, tibiaBinary)
+
+	printDiagnosisReport(diagnosis, "target")
+
+	if compareWith != "" {
+		comparePath, compareBinary := readFile(compareWith)
+		compareDiagnosis := analyzeTibiaBinary(comparePath, compareBinary)
+		printDiagnosisReport(compareDiagnosis, "baseline")
+		printDiagnosisComparison(compareDiagnosis, diagnosis)
+	}
+
+	failIfStrictClientCheck(diagnosis, strictClientCheck)
+}
+
+func backupTibiaExecutable(tibiaPath string, tibiaBinary []byte, aggressive bool) {
 	tibiaExeFileName := filepath.Base(tibiaPath)
 	tibiaExeBackupPath := filepath.Join(filepath.Dir(tibiaPath), fmt.Sprintf("BKP%d-%s", time.Now().Unix(), tibiaExeFileName))
 	tibiaExeBackupFileName := filepath.Base(tibiaExeBackupPath)
+
+	if aggressive {
+		fmt.Printf("[WARN] ============================================================\n")
+		fmt.Printf("[WARN] AGGRESSIVE MODE IS ENABLED\n")
+		fmt.Printf("[WARN] High-risk signatures are being rewritten automatically.\n")
+		fmt.Printf("[WARN] This mode can break runtime behavior and can crash or fail to start some clients.\n")
+		fmt.Printf("[WARN] Create/keep a known-good backup before using it.\n")
+		fmt.Printf("[WARN] This may alter client behavior and should only be used with full manual validation.\n")
+		fmt.Printf("[WARN] ============================================================\n")
+	}
 
 	fmt.Printf("[INFO] Backing up %s to %s\n", tibiaExeFileName, tibiaExeBackupFileName)
 
@@ -119,11 +369,11 @@ func replaceTibiaRSAKey(tibiaBinary []byte) []byte {
 
 	fmt.Printf("[INFO] Searching for Tibia RSA... \n")
 
-	if bytes.ContainsAny(tibiaBinary, string(tibiaRsa)) {
+	if bytes.Contains(tibiaBinary, tibiaRsa) {
 		fmt.Printf("[INFO] Tibia RSA found!\n")
 		tibiaBinary = bytes.Replace(tibiaBinary, tibiaRsa, otservRsa, 1)
 		fmt.Printf("[PATCH] Tibia RSA replaced with OTServ RSA!\n")
-	} else if bytes.ContainsAny(tibiaBinary, string(otservRsa)) {
+	} else if bytes.Contains(tibiaBinary, otservRsa) {
 		fmt.Printf("[WARN] OTServ RSA already patched!\n")
 	} else {
 		fmt.Printf("[ERROR] Unable to find Tibia RSA\n")
@@ -133,37 +383,129 @@ func replaceTibiaRSAKey(tibiaBinary []byte) []byte {
 	return tibiaBinary
 }
 
-func removeBattlEye(tibiaPath string, tibiaBinary []byte) []byte {
+func removeBattlEye(tibiaPath string, tibiaBinary []byte, aggressive bool) []byte {
 	if !isWindowsExecutable(tibiaPath, tibiaBinary) {
 		fmt.Printf("[WARN] Battleye patch skipped because the client is not a Windows executable\n")
 		return tibiaBinary
 	}
 
-	fmt.Printf("[INFO] Searching for Battleye... \n")
+	fmt.Printf("[INFO] Searching for BattlEye byte patch signatures...\n")
+	if aggressive {
+		fmt.Printf("[WARN] Aggressive mode enabled: high-risk signatures are eligible for patching.\n")
+	}
+
+	activeBattleyePatches := make([]battleyePatch, len(battleyePatches))
+	for patchIndex, patch := range battleyePatches {
+		activeBattleyePatches[patchIndex] = patch.withAggressiveMode(aggressive)
+	}
 
 	patchesApplied := 0
-	for _, patch := range battleyePatches {
-		count := bytes.Count(tibiaBinary, patch.from)
-		if count == 0 {
+	signaturesApplied := 0
+	alreadyApplied := 0
+	patchableSignatures := 0
+	for _, patch := range activeBattleyePatches {
+		if !patch.diagnosticOnly || (aggressive && len(patch.aggressiveReplacement) > 0) {
+			patchableSignatures++
+		}
+	}
+	for _, patch := range activeBattleyePatches {
+		originalOffsets := patch.original.findAll(tibiaBinary)
+		patchedOffsets := patch.patched.findAll(tibiaBinary)
+
+		if patch.diagnosticOnly {
+			if len(originalOffsets) > 0 && aggressive && len(patch.aggressiveReplacement) > 0 {
+				aggressivePatch := patch
+				aggressivePatch.diagnosticOnly = false
+				aggressivePatch.replacement = append([]int(nil), patch.aggressiveReplacement...)
+				aggressivePatch.patched = newBytePattern(patch.name+" [aggressive]", patch.aggressiveReplacement...)
+
+				tibiaBinary = applyBattleyePatch(tibiaBinary, aggressivePatch, originalOffsets)
+				count := len(originalOffsets)
+				patchesApplied += count
+				signaturesApplied++
+				fmt.Printf("[PATCH] BattlEye high-risk signature %q patched aggressively (%d occurrence(s))\n", patch.name, count)
+				continue
+			}
+
+			if len(originalOffsets) > 0 || len(patchedOffsets) > 0 {
+				fmt.Printf("[INFO] BattlEye diagnostic signature %q found original=%s patched=%s; not applied automatically\n", patch.name, formatOffsetsLimited(originalOffsets, 6), formatOffsetsLimited(patchedOffsets, 6))
+			}
 			continue
 		}
-		tibiaBinary = bytes.ReplaceAll(tibiaBinary, patch.from, patch.to)
-		patchesApplied += count
+
+		if len(originalOffsets) > 0 {
+			tibiaBinary = applyBattleyePatch(tibiaBinary, patch, originalOffsets)
+			count := len(originalOffsets)
+			patchesApplied += count
+			signaturesApplied++
+			fmt.Printf("[PATCH] BattlEye signature %q patched (%d occurrence(s))\n", patch.name, count)
+			continue
+		}
+
+		patchedCount := len(patchedOffsets)
+		if patchedCount > 0 {
+			alreadyApplied += patchedCount
+			fmt.Printf("[INFO] BattlEye signature %q already patched (%d occurrence(s))\n", patch.name, patchedCount)
+			continue
+		}
+
+		fmt.Printf("[INFO] BattlEye signature %q not found\n", patch.name)
 	}
 
 	if patchesApplied > 0 {
-		fmt.Printf("[INFO] Battleye found!\n")
-		fmt.Printf("[PATCH] Battleye removed! Applied %d patch(es)\n", patchesApplied)
+		fmt.Printf("[PATCH] BattlEye byte patch summary: applied %d occurrence(s) across %d/%d patchable signature(s)\n", patchesApplied, signaturesApplied, patchableSignatures)
+		if signaturesApplied < patchableSignatures {
+			fmt.Printf("[WARN] BattlEye byte patch is partial for this binary; missing signatures can mean this client version uses different code paths\n")
+		}
+		if hasClientCheckStringIndicators(tibiaBinary) {
+			fmt.Printf("[WARN] Client-check strings remain after BattlEye patching; this edit should be treated as PARTIAL unless code-reference diagnostics prove the paths inactive\n")
+		}
 		return tibiaBinary
 	}
 
-	if hasAppliedBattlEyePatch(tibiaBinary) {
-		fmt.Printf("[WARN] Battleye already removed!\n")
+	if alreadyApplied > 0 {
+		fmt.Printf("[WARN] BattlEye byte patches were already present (%d occurrence(s)); no new byte patch was applied\n", alreadyApplied)
+		if hasClientCheckStringIndicators(tibiaBinary) {
+			fmt.Printf("[WARN] Client-check strings remain in an already patched binary; this should be treated as PARTIAL unless code-reference diagnostics prove the paths inactive\n")
+		}
 		return tibiaBinary
 	}
 
-	fmt.Printf("[WARN] Battleye not found\n")
+	fmt.Printf("[WARN] BattlEye byte patch signatures not found\n")
+	if hasClientCheckStringIndicators(tibiaBinary) {
+		fmt.Printf("[WARN] Client-check strings remain and no patchable BattlEye signature matched; this binary is likely unsupported by the current patch set\n")
+	}
 	return tibiaBinary
+}
+
+func logBattlEyeSignatureReport(patchStatuses []battleyePatchStatus) {
+	fmt.Printf("[INFO] Known BattlEye byte patch signature report:\n")
+	for _, status := range patchStatuses {
+		signatureKind := "patchable"
+		if status.patch.diagnosticOnly {
+			signatureKind = "diagnostic-only"
+		}
+
+		switch {
+		case len(status.originalOffset) > 0:
+			fmt.Printf("[WARN] %q (%s) original signature present at %s\n", status.patch.name, signatureKind, formatOffsets(status.originalOffset))
+		case len(status.patchedOffset) > 0:
+			fmt.Printf("[INFO] %q (%s) patched signature present at %s\n", status.patch.name, signatureKind, formatOffsets(status.patchedOffset))
+		default:
+			fmt.Printf("[INFO] %q (%s) signature not found\n", status.patch.name, signatureKind)
+		}
+
+		for _, expected := range status.expectedOffsetHits {
+			fmt.Printf("[INFO]   expected offset hit 0x%X for SHA256 %s: %s\n", expected.offset, expected.sha256, expected.note)
+		}
+		for _, expected := range status.expectedOffsetMisses {
+			fmt.Printf("[WARN]   expected offset miss 0x%X for SHA256 %s: %s\n", expected.offset, expected.sha256, expected.note)
+		}
+		if status.patch.diagnosticOnly && status.patch.falsePositiveCheck != "" {
+			fmt.Printf("[INFO]   aob mask: %s\n", status.patch.original.formatAOB())
+			fmt.Printf("[INFO]   false-positive guard: %s\n", status.patch.falsePositiveCheck)
+		}
+	}
 }
 
 func isWindowsExecutable(_ string, tibiaBinary []byte) bool {
@@ -182,13 +524,1366 @@ func isWindowsExecutable(_ string, tibiaBinary []byte) bool {
 		tibiaBinary[peOffset+3] == 0x00
 }
 
-func hasAppliedBattlEyePatch(tibiaBinary []byte) bool {
+func analyzeTibiaBinary(tibiaPath string, tibiaBinary []byte) diagnosisReport {
+	sum := sha256.Sum256(tibiaBinary)
+	diagnosis := diagnosisReport{
+		path:          tibiaPath,
+		size:          len(tibiaBinary),
+		sha256:        fmt.Sprintf("%x", sum[:]),
+		isWindowsExe:  isWindowsExecutable(tibiaPath, tibiaBinary),
+		patchStatuses: scanBattlEyePatchStatus(tibiaBinary),
+	}
+
+	if diagnosis.isWindowsExe {
+		diagnosis.pe = inspectPE(tibiaBinary)
+	}
+
+	diagnosis.clientCheckFindings = scanClientCheckFindings(tibiaBinary, diagnosis.pe, diagnosis.patchStatuses)
+	diagnosis.qtIndicators = scanQtContextIndicators(tibiaBinary, diagnosis.pe)
+	return diagnosis
+}
+
+func scanBattlEyePatchStatus(tibiaBinary []byte) []battleyePatchStatus {
+	sum := sha256.Sum256(tibiaBinary)
+	sha256Text := fmt.Sprintf("%x", sum[:])
+	statuses := make([]battleyePatchStatus, 0, len(battleyePatches))
 	for _, patch := range battleyePatches {
-		if bytes.Contains(tibiaBinary, patch.to) {
+		patchedOffsets := patch.patched.findAll(tibiaBinary)
+		if patch.diagnosticOnly && len(patch.aggressiveReplacement) > 0 {
+			patchedOffsets = append(patchedOffsets, newBytePattern(patch.name+" [aggressive]", patch.aggressiveReplacement...).findAll(tibiaBinary)...)
+		}
+		statuses = append(statuses, battleyePatchStatus{
+			patch:                patch,
+			originalOffset:       patch.original.findAll(tibiaBinary),
+			patchedOffset:        patchedOffsets,
+			expectedOffsetHits:   patch.expectedOffsetHits(tibiaBinary, sha256Text),
+			expectedOffsetMisses: patch.expectedOffsetMisses(tibiaBinary, sha256Text),
+		})
+	}
+	return statuses
+}
+
+func inspectPE(tibiaBinary []byte) peInfo {
+	peFile, err := pe.NewFile(bytes.NewReader(tibiaBinary))
+	if err != nil {
+		return peInfo{errorText: err.Error()}
+	}
+	defer peFile.Close()
+
+	info := peInfo{valid: true}
+	switch optionalHeader := peFile.OptionalHeader.(type) {
+	case *pe.OptionalHeader32:
+		info.imageBase = uint64(optionalHeader.ImageBase)
+	case *pe.OptionalHeader64:
+		info.imageBase = optionalHeader.ImageBase
+	}
+
+	for _, section := range peFile.Sections {
+		rawStart := int(section.Offset)
+		rawEnd := rawStart + int(section.Size)
+		if rawStart > len(tibiaBinary) {
+			continue
+		}
+		if rawEnd > len(tibiaBinary) {
+			rawEnd = len(tibiaBinary)
+		}
+		if rawEnd <= rawStart {
+			continue
+		}
+
+		virtualSize := int(section.VirtualSize)
+		if virtualSize < int(section.Size) {
+			virtualSize = int(section.Size)
+		}
+
+		info.sections = append(info.sections, peSectionInfo{
+			name:     strings.TrimRight(section.Name, "\x00"),
+			rawStart: rawStart,
+			rawEnd:   rawEnd,
+			rvaStart: int(section.VirtualAddress),
+			rvaEnd:   int(section.VirtualAddress) + virtualSize,
+			isCode:   section.Characteristics&0x00000020 != 0 || section.Characteristics&0x20000000 != 0,
+		})
+	}
+
+	if libraries, err := peFile.ImportedLibraries(); err == nil {
+		info.imports = append(info.imports, libraries...)
+	}
+	if symbols, err := peFile.ImportedSymbols(); err == nil {
+		info.imports = append(info.imports, symbols...)
+	}
+	sort.Strings(info.imports)
+
+	return info
+}
+
+func scanClientCheckFindings(tibiaBinary []byte, peData peInfo, patchStatuses []battleyePatchStatus) []clientCheckFinding {
+	findings := make([]clientCheckFinding, 0)
+	for _, indicator := range clientCheckIndicators {
+		findings = appendClientCheckFinding(findings, tibiaBinary, peData, patchStatuses, indicator.name, "ascii", indicator.value)
+
+		utf16Value := utf16LEBytes(string(indicator.value))
+		if len(utf16Value) > 0 {
+			findings = appendClientCheckFinding(findings, tibiaBinary, peData, patchStatuses, indicator.name, "utf16-le", utf16Value)
+		}
+	}
+	return findings
+}
+
+func appendClientCheckFinding(findings []clientCheckFinding, tibiaBinary []byte, peData peInfo, patchStatuses []battleyePatchStatus, name string, encoding string, needle []byte) []clientCheckFinding {
+	offsets := findAllOffsets(tibiaBinary, needle)
+	if len(offsets) == 0 {
+		return findings
+	}
+
+	finding := clientCheckFinding{
+		name:     name,
+		encoding: encoding,
+		offsets:  offsets,
+	}
+
+	if peData.valid {
+		for _, offset := range offsets {
+			finding.references = append(finding.references, findStringCodeReferences(tibiaBinary, peData, patchStatuses, name, offset)...)
+		}
+	}
+
+	return append(findings, finding)
+}
+
+func findStringCodeReferences(tibiaBinary []byte, peData peInfo, patchStatuses []battleyePatchStatus, indicatorName string, stringOffset int) []clientCheckReference {
+	stringRVA, ok := peData.rvaForOffset(stringOffset)
+	if !ok {
+		return nil
+	}
+
+	references := make([]clientCheckReference, 0)
+	for _, section := range peData.sections {
+		if !section.isCode {
+			continue
+		}
+
+		for offset := section.rawStart; offset < section.rawEnd; offset++ {
+			instructionLength, instructionName, displacementOffset, ok := ripRelativeInstructionAt(tibiaBinary, section.rawEnd, offset)
+			if !ok {
+				continue
+			}
+
+			instructionRVA, ok := peData.rvaForOffset(offset)
+			if !ok {
+				continue
+			}
+
+			displacement := int(int32(binary.LittleEndian.Uint32(tibiaBinary[displacementOffset : displacementOffset+4])))
+			targetRVA := instructionRVA + instructionLength + displacement
+			if targetRVA != stringRVA {
+				continue
+			}
+
+			reference := clientCheckReference{
+				offset:      offset,
+				section:     section.name,
+				instruction: instructionName,
+			}
+			reference = enrichCodeReferenceContext(tibiaBinary, section, reference, patchStatuses, indicatorName)
+			references = append(references, reference)
+		}
+	}
+
+	return dedupeAdjacentRexReferences(references)
+}
+
+func dedupeAdjacentRexReferences(references []clientCheckReference) []clientCheckReference {
+	deduped := make([]clientCheckReference, 0, len(references))
+	for _, reference := range references {
+		if len(deduped) > 0 {
+			previous := deduped[len(deduped)-1]
+			if reference.offset == previous.offset+1 &&
+				strings.Contains(previous.instruction, "REX:") &&
+				(reference.instruction == "LEA" || reference.instruction == "MOV") {
+				continue
+			}
+		}
+		deduped = append(deduped, reference)
+	}
+	return deduped
+}
+
+func ripRelativeInstructionAt(tibiaBinary []byte, sectionEnd int, offset int) (int, string, int, bool) {
+	if offset >= sectionEnd {
+		return 0, "", 0, false
+	}
+
+	opcodeOffset := offset
+	rexPrefix := byte(0)
+	if tibiaBinary[opcodeOffset]&0xf0 == 0x40 {
+		rexPrefix = tibiaBinary[opcodeOffset]
+		opcodeOffset++
+	}
+
+	if opcodeOffset+6 > sectionEnd || opcodeOffset+6 > len(tibiaBinary) {
+		return 0, "", 0, false
+	}
+
+	opcode := tibiaBinary[opcodeOffset]
+	if opcode != 0x8d && opcode != 0x8b {
+		return 0, "", 0, false
+	}
+
+	modRM := tibiaBinary[opcodeOffset+1]
+	if modRM&0xc7 != 0x05 {
+		return 0, "", 0, false
+	}
+
+	instructionLength := opcodeOffset - offset + 6
+	instructionName := "rip-relative"
+	if opcode == 0x8d {
+		instructionName = "LEA"
+	} else if opcode == 0x8b {
+		instructionName = "MOV"
+	}
+	if rexPrefix != 0 {
+		instructionName = fmt.Sprintf("%s REX:%02X", instructionName, rexPrefix)
+	}
+
+	return instructionLength, instructionName, opcodeOffset + 2, true
+}
+
+func enrichCodeReferenceContext(tibiaBinary []byte, section peSectionInfo, reference clientCheckReference, patchStatuses []battleyePatchStatus, indicatorName string) clientCheckReference {
+	windowStart := reference.offset - codeContextRadius
+	if windowStart < section.rawStart {
+		windowStart = section.rawStart
+	}
+	windowEnd := reference.offset + codeContextRadius
+	if windowEnd > section.rawEnd {
+		windowEnd = section.rawEnd
+	}
+
+	reference.branchOffsets = findConditionalBranches(tibiaBinary, windowStart, windowEnd)
+	reference.callOffsets = findCalls(tibiaBinary, windowStart, windowEnd)
+	reference.patternMatches = findCodePatternMatches(tibiaBinary, windowStart, windowEnd)
+	reference.knownPatchNearby = hasKnownPatchNearby(patchStatuses, reference.contextOffsets(), knownPatchContextRadius)
+	reference.contextStart, reference.contextBytes = bytesAround(tibiaBinary, reference.offset, contextBytesRadius)
+	reference.strongUnsupported = isStrongClientCheckEvidence(indicatorName, reference)
+	reference.suspiciousActive = isSuspiciousActiveClientCheckEvidence(indicatorName, reference)
+
+	return reference
+}
+
+func findConditionalBranches(tibiaBinary []byte, start int, end int) []int {
+	offsets := make([]int, 0)
+	for offset := start; offset < end && offset < len(tibiaBinary); offset++ {
+		if isConditionalJump(tibiaBinary, offset, end) {
+			offsets = append(offsets, offset)
+		}
+	}
+	return offsets
+}
+
+func isStrongClientCheckEvidence(indicatorName string, reference clientCheckReference) bool {
+	if !isCriticalClientCheckIndicator(indicatorName) {
+		return false
+	}
+	if reference.knownPatchNearby {
+		return false
+	}
+	if len(reference.branchOffsets) == 0 {
+		return false
+	}
+
+	// Branches near Qt meta-object string references are common. Require a
+	// recognized branch/call pattern before escalating from weak to strong.
+	return len(reference.patternMatches) > 0
+}
+
+func isSuspiciousActiveClientCheckEvidence(indicatorName string, reference clientCheckReference) bool {
+	if reference.strongUnsupported {
+		return false
+	}
+	if !isCriticalClientCheckIndicator(indicatorName) {
+		return false
+	}
+	if len(reference.branchOffsets) == 0 || len(reference.callOffsets) == 0 {
+		return false
+	}
+	return true
+}
+
+func isCriticalClientCheckIndicator(indicatorName string) bool {
+	switch indicatorName {
+	case "clientcheck_disconnected",
+		"onCloseDueToClientCheckRequested",
+		"onClientCheckDialogButtonClicked",
+		"enableClientCheck",
+		"requestCloseDueToClientCheck":
+		return true
+	default:
+		return false
+	}
+}
+
+func isConditionalJump(data []byte, offset int, end int) bool {
+	if offset < 0 || offset >= end || offset >= len(data) {
+		return false
+	}
+
+	opcode := data[offset]
+	if opcode >= 0x70 && opcode <= 0x7f {
+		return true
+	}
+
+	return offset+1 < end &&
+		offset+1 < len(data) &&
+		opcode == 0x0f &&
+		data[offset+1] >= 0x80 &&
+		data[offset+1] <= 0x8f
+}
+
+func findCalls(tibiaBinary []byte, start int, end int) []int {
+	offsets := make([]int, 0)
+	for offset := start; offset < end && offset < len(tibiaBinary); offset++ {
+		if offset+5 <= end && tibiaBinary[offset] == 0xe8 {
+			offsets = append(offsets, offset)
+			continue
+		}
+		if offset+2 <= end && tibiaBinary[offset] == 0xff && tibiaBinary[offset+1]&0x38 == 0x10 {
+			offsets = append(offsets, offset)
+		}
+	}
+	return offsets
+}
+
+func findCodePatternMatches(tibiaBinary []byte, start int, end int) []patternMatch {
+	matches := make([]patternMatch, 0)
+	if start < 0 {
+		start = 0
+	}
+	if end > len(tibiaBinary) {
+		end = len(tibiaBinary)
+	}
+	if end <= start {
+		return matches
+	}
+
+	window := tibiaBinary[start:end]
+	for _, pattern := range clientCheckCodePatterns {
+		for _, offset := range pattern.findAll(window) {
+			matches = append(matches, patternMatch{name: pattern.name, offset: start + offset})
+		}
+	}
+	return matches
+}
+
+func hasKnownPatchNearby(patchStatuses []battleyePatchStatus, referenceOffsets []int, radius int) bool {
+	for _, status := range patchStatuses {
+		for _, knownOffset := range append(append([]int{}, status.originalOffset...), status.patchedOffset...) {
+			for _, referenceOffset := range referenceOffsets {
+				if absDistance(referenceOffset, knownOffset) <= radius {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func (reference clientCheckReference) contextOffsets() []int {
+	offsets := []int{reference.offset}
+	offsets = append(offsets, reference.branchOffsets...)
+	offsets = append(offsets, reference.callOffsets...)
+	for _, match := range reference.patternMatches {
+		offsets = append(offsets, match.offset)
+	}
+	return offsets
+}
+
+func scanQtContextIndicators(tibiaBinary []byte, peData peInfo) []string {
+	seen := make(map[string]struct{})
+	for _, indicator := range qtContextIndicators {
+		if bytes.Contains(tibiaBinary, []byte(indicator)) {
+			seen[indicator+" string"] = struct{}{}
+		}
+		lowerIndicator := strings.ToLower(indicator)
+		for _, importedName := range peData.imports {
+			if strings.Contains(strings.ToLower(importedName), lowerIndicator) {
+				seen[indicator+" import"] = struct{}{}
+			}
+		}
+	}
+
+	indicators := make([]string, 0, len(seen))
+	for indicator := range seen {
+		indicators = append(indicators, indicator)
+	}
+	sort.Strings(indicators)
+	return indicators
+}
+
+func printDiagnosisReport(diagnosis diagnosisReport, label string) {
+	fmt.Printf("[INFO] Diagnosing %s: %s\n", label, diagnosis.path)
+	fmt.Printf("[INFO] Size: %d bytes\n", diagnosis.size)
+	fmt.Printf("[INFO] SHA256: %s\n", diagnosis.sha256)
+
+	if !diagnosis.isWindowsExe {
+		fmt.Printf("[WARN] This file is not a Windows PE executable; BattlEye byte patch signatures are informational only\n")
+	}
+	if diagnosis.isWindowsExe && !diagnosis.pe.valid {
+		fmt.Printf("[WARN] PE section parsing failed; code-reference diagnostics are unavailable: %s\n", diagnosis.pe.errorText)
+	}
+
+	logBattlEyeSignatureReport(diagnosis.patchStatuses)
+	logClientCheckSupportSummary(diagnosis)
+}
+
+func logClientCheckSupportSummary(diagnosis diagnosisReport) {
+	fmt.Printf("[INFO] Client-check support verdict: %s\n", diagnosis.clientCheckVerdict())
+	fmt.Printf("[INFO] Known byte-patch coverage: %d/%d signature(s), original=%d, patched=%d\n",
+		diagnosis.knownPatchCoverage(),
+		patchableBattleyePatchCount(),
+		diagnosis.originalPatchSignatureCount(),
+		diagnosis.patchedPatchSignatureCount(),
+	)
+
+	if len(diagnosis.clientCheckFindings) == 0 {
+		fmt.Printf("[INFO] No known client-check string indicators remain\n")
+		return
+	}
+
+	logStrongUnsupportedEvidence(diagnosis)
+	logSuspiciousActiveClientCheckEvidence(diagnosis)
+	logWeakClientCheckIndicators(diagnosis)
+
+	if len(diagnosis.qtIndicators) > 0 {
+		fmt.Printf("[INFO] Qt context indicators: %s\n", strings.Join(diagnosis.qtIndicators, ", "))
+	}
+
+	if diagnosis.strongUnsupportedEvidenceCount() > 0 {
+		fmt.Printf("[ERROR] Strong unsupported client-check evidence remains: %d code reference(s) combine a critical client-check string, nearby conditional branch, recognized branch/call pattern, and no known patch signature nearby\n", diagnosis.strongUnsupportedEvidenceCount())
+	}
+	if diagnosis.hasPatchedClientCheckSignature() && diagnosis.highRiskClientCheckDiagnosticCount() > 0 {
+		fmt.Printf("[WARN] High-risk diagnostic-only client-check paths remain after a known patch was applied: %d signature(s)\n", diagnosis.highRiskClientCheckDiagnosticCount())
+	}
+	if diagnosis.hasPatchedClientCheckSignature() && diagnosis.suspiciousActiveEvidenceCount() > 0 {
+		fmt.Printf("[WARN] Suspicious active client-check branch/call evidence remains after a known patch was applied: %d code reference(s)\n", diagnosis.suspiciousActiveEvidenceCount())
+	}
+}
+
+func logStrongUnsupportedEvidence(diagnosis diagnosisReport) {
+	strongCount := diagnosis.strongUnsupportedEvidenceCount()
+	if strongCount == 0 {
+		fmt.Printf("[INFO] Strong unsupported evidence: none\n")
+		return
+	}
+
+	fmt.Printf("[ERROR] Strong unsupported evidence:\n")
+	for _, finding := range diagnosis.clientCheckFindings {
+		for _, reference := range finding.references {
+			if !reference.strongUnsupported {
+				continue
+			}
+			fmt.Printf("[ERROR]   %q (%s) string=%s ref=%s at 0x%X in %s branches=%s calls=%s patterns=%s knownPatchNearby=%t context48=%s possibleInstructions=%s\n",
+				finding.name,
+				finding.encoding,
+				formatOffsetsLimited(finding.offsets, 4),
+				reference.instruction,
+				reference.offset,
+				reference.section,
+				formatNearestOffsets(reference.offset, reference.branchOffsets, 6),
+				formatNearestOffsets(reference.offset, reference.callOffsets, 6),
+				formatPatternMatches(reference.patternMatches, 4),
+				reference.knownPatchNearby,
+				formatBytes(reference.contextBytes),
+				formatPossibleInstructions(reference),
+			)
+		}
+	}
+}
+
+func logSuspiciousActiveClientCheckEvidence(diagnosis diagnosisReport) {
+	suspiciousCount := diagnosis.suspiciousActiveEvidenceCount()
+	if suspiciousCount == 0 {
+		fmt.Printf("[INFO] Suspicious active client-check candidates: none\n")
+		return
+	}
+
+	fmt.Printf("[WARN] Suspicious active client-check candidates:\n")
+	for _, finding := range diagnosis.clientCheckFindings {
+		for _, reference := range finding.references {
+			if !reference.suspiciousActive {
+				continue
+			}
+			fmt.Printf("[WARN]   %q (%s) string=%s ref=%s at 0x%X in %s nearestBranches=%s nearestCalls=%s patterns=%s knownPatchNearby=%t reason=%s context48=%s possibleInstructions=%s\n",
+				finding.name,
+				finding.encoding,
+				formatOffsetsLimited(finding.offsets, 4),
+				reference.instruction,
+				reference.offset,
+				reference.section,
+				formatNearestOffsets(reference.offset, reference.branchOffsets, 8),
+				formatNearestOffsets(reference.offset, reference.callOffsets, 8),
+				formatPatternMatches(reference.patternMatches, 4),
+				reference.knownPatchNearby,
+				suspiciousEvidenceReason(finding.name, reference),
+				formatBytes(reference.contextBytes),
+				formatPossibleInstructions(reference),
+			)
+		}
+	}
+}
+
+func logWeakClientCheckIndicators(diagnosis diagnosisReport) {
+	fmt.Printf("[WARN] Weak indicators:\n")
+	for _, finding := range diagnosis.clientCheckFindings {
+		if len(finding.references) == 0 {
+			fmt.Printf("[WARN]   %q (%s) string=%s refs=none reason=no code xref found\n", finding.name, finding.encoding, formatOffsetsLimited(finding.offsets, 8))
+			continue
+		}
+
+		for _, reference := range finding.references {
+			if reference.strongUnsupported || reference.suspiciousActive {
+				continue
+			}
+			fmt.Printf("[WARN]   %q (%s) string=%s ref=%s at 0x%X in %s nearestBranches=%s nearestCalls=%s patterns=%s knownPatchNearby=%t reason=%s context48=%s possibleInstructions=%s\n",
+				finding.name,
+				finding.encoding,
+				formatOffsetsLimited(finding.offsets, 4),
+				reference.instruction,
+				reference.offset,
+				reference.section,
+				formatNearestOffsets(reference.offset, reference.branchOffsets, 8),
+				formatNearestOffsets(reference.offset, reference.callOffsets, 8),
+				formatPatternMatches(reference.patternMatches, 4),
+				reference.knownPatchNearby,
+				weakEvidenceReason(finding.name, reference),
+				formatBytes(reference.contextBytes),
+				formatPossibleInstructions(reference),
+			)
+		}
+	}
+}
+
+func suspiciousEvidenceReason(indicatorName string, reference clientCheckReference) string {
+	if !isCriticalClientCheckIndicator(indicatorName) {
+		return "non-critical indicator"
+	}
+	if len(reference.branchOffsets) == 0 {
+		return "no conditional branch in context"
+	}
+	if len(reference.callOffsets) == 0 {
+		return "no call in context"
+	}
+	if reference.knownPatchNearby {
+		return "critical indicator has nearby branch and call; known nearby signature lowers this from strong to warning"
+	}
+	if len(reference.patternMatches) == 0 {
+		return "critical indicator has nearby branch and call but no recognized branch/call signature"
+	}
+	return "candidate remains below strong-evidence threshold"
+}
+
+func weakEvidenceReason(indicatorName string, reference clientCheckReference) string {
+	switch {
+	case !isCriticalClientCheckIndicator(indicatorName):
+		return "non-critical indicator"
+	case reference.knownPatchNearby:
+		return "known patch signature nearby"
+	case len(reference.branchOffsets) == 0:
+		return "no conditional branch in context"
+	case len(reference.callOffsets) == 0:
+		return "no call in context"
+	case len(reference.patternMatches) == 0:
+		return "no recognized branch/call pattern in context"
+	default:
+		return "not escalated"
+	}
+}
+
+func printDiagnosisComparison(baseline diagnosisReport, target diagnosisReport) {
+	fmt.Printf("[INFO] Comparative diagnosis: baseline=%s target=%s\n", baseline.path, target.path)
+	fmt.Printf("[INFO] Size delta: %+d bytes\n", target.size-baseline.size)
+	if baseline.sha256 == target.sha256 {
+		fmt.Printf("[INFO] SHA256: identical\n")
+	} else {
+		fmt.Printf("[INFO] SHA256: baseline=%s target=%s\n", baseline.sha256, target.sha256)
+	}
+
+	fmt.Printf("[INFO] Known patch coverage: baseline=%d/%d target=%d/%d\n",
+		baseline.knownPatchCoverage(),
+		patchableBattleyePatchCount(),
+		target.knownPatchCoverage(),
+		patchableBattleyePatchCount(),
+	)
+	for _, patch := range battleyePatches {
+		fmt.Printf("[INFO] Patch %q: baseline=%s target=%s\n",
+			patch.name,
+			baseline.patchStateByName(patch.name),
+			target.patchStateByName(patch.name),
+		)
+	}
+
+	fmt.Printf("[INFO] Client-check indicators: baseline=%d target=%d\n", baseline.clientCheckIndicatorCount(), target.clientCheckIndicatorCount())
+	fmt.Printf("[INFO] Client-check code refs: baseline=%d target=%d\n", baseline.clientCheckCodeReferenceCount(), target.clientCheckCodeReferenceCount())
+	fmt.Printf("[INFO] Strong unsupported evidence: baseline=%d target=%d\n", baseline.strongUnsupportedEvidenceCount(), target.strongUnsupportedEvidenceCount())
+	fmt.Printf("[INFO] Suspicious active candidates: baseline=%d target=%d\n", baseline.suspiciousActiveEvidenceCount(), target.suspiciousActiveEvidenceCount())
+
+	newIndicators := differenceStrings(target.clientCheckIndicatorKeys(), baseline.clientCheckIndicatorKeys())
+	if len(newIndicators) > 0 {
+		fmt.Printf("[WARN] New target-only client-check indicators: %s\n", strings.Join(newIndicators, ", "))
+	}
+
+	newStrongEvidence := differenceStrings(target.strongUnsupportedEvidenceKeys(), baseline.strongUnsupportedEvidenceKeys())
+	if len(newStrongEvidence) > 0 {
+		fmt.Printf("[ERROR] Target-only strong unsupported evidence: %s\n", strings.Join(newStrongEvidence, "; "))
+	}
+
+	newSuspiciousEvidence := differenceStrings(target.suspiciousActiveIndicatorKeys(), baseline.suspiciousActiveIndicatorKeys())
+	if len(newSuspiciousEvidence) > 0 {
+		fmt.Printf("[WARN] Target-only suspicious active candidates: %s\n", strings.Join(newSuspiciousEvidence, "; "))
+	}
+}
+
+func enforceEditClientCheckPolicy(diagnosis diagnosisReport, strictClientCheck bool) {
+	verdict := diagnosis.clientCheckVerdict()
+	if diagnosis.strongUnsupportedEvidenceCount() > 0 {
+		fmt.Printf("[ERROR] UNSUPPORTED support - refusing export because strong client-check evidence remains (%d code reference(s))\n", diagnosis.strongUnsupportedEvidenceCount())
+		fmt.Printf("[ERROR] Verdict: %s\n", verdict)
+		fmt.Printf("[ERROR] Run diagnose and inspect the Strong unsupported evidence section before using this client\n")
+		os.Exit(1)
+	}
+
+	if diagnosis.isPartialClientCheckSupport() {
+		if strictClientCheck {
+			fmt.Printf("[ERROR] PARTIAL support - refusing export because --strict is enabled\n")
+			fmt.Printf("[ERROR] Verdict: %s\n", verdict)
+			fmt.Printf("[ERROR] Re-run without --strict only if this partial support is acceptable for manual testing\n")
+			os.Exit(1)
+		}
+
+		fmt.Printf("[WARN] PARTIAL support - client may work but not fully verified\n")
+		fmt.Printf("[WARN] Verdict: %s\n", verdict)
+		return
+	}
+
+	if diagnosis.isWarningClientCheckSupport() {
+		if strictClientCheck {
+			fmt.Printf("[ERROR] WARNING support - refusing export because --strict is enabled\n")
+			fmt.Printf("[ERROR] Verdict: %s\n", verdict)
+			fmt.Printf("[ERROR] Re-run diagnose and inspect Suspicious active client-check candidates before using this client\n")
+			os.Exit(1)
+		}
+
+		fmt.Printf("[WARN] WARNING support - client-check branch/call candidates remain after the known patch\n")
+		fmt.Printf("[WARN] Client-check paths may still be active. Test recommended.\n")
+		fmt.Printf("[WARN] Verdict: %s\n", verdict)
+		return
+	}
+
+	fmt.Printf("[INFO] Client-check edit gate: %s\n", verdict)
+}
+
+func failIfStrictClientCheck(diagnosis diagnosisReport, strictClientCheck bool) {
+	if !strictClientCheck || !diagnosis.hasUnsafeClientCheckRemainder() {
+		return
+	}
+
+	fmt.Printf("[ERROR] Refusing to continue because strict client-check validation is enabled and the verdict is %s\n", diagnosis.clientCheckVerdict())
+	os.Exit(1)
+}
+
+func (diagnosis diagnosisReport) hasUnsafeClientCheckRemainder() bool {
+	return diagnosis.isPartialClientCheckSupport() || diagnosis.isWarningClientCheckSupport() || diagnosis.strongUnsupportedEvidenceCount() > 0
+}
+
+func (diagnosis diagnosisReport) isPartialClientCheckSupport() bool {
+	return strings.HasPrefix(diagnosis.clientCheckVerdict(), "PARTIAL:")
+}
+
+func (diagnosis diagnosisReport) isWarningClientCheckSupport() bool {
+	return strings.HasPrefix(diagnosis.clientCheckVerdict(), "WARNING:")
+}
+
+func logEditSuccess(diagnosis diagnosisReport, strictClientCheck bool) {
+	if diagnosis.isPartialClientCheckSupport() {
+		fmt.Printf("[WARN] Edit completed with PARTIAL support - client may work but not fully verified (strict=%t)\n", strictClientCheck)
+		return
+	}
+	if diagnosis.isWarningClientCheckSupport() {
+		fmt.Printf("[WARN] Edit completed with WARNING support - suspicious client-check branch/call candidates remain (strict=%t)\n", strictClientCheck)
+		fmt.Printf("[WARN] Client-check paths may still be active. Test recommended.\n")
+		return
+	}
+
+	fmt.Printf("[INFO] Edit completed with %s\n", diagnosis.clientCheckVerdict())
+}
+
+func (diagnosis diagnosisReport) clientCheckVerdict() string {
+	strongEvidenceCount := diagnosis.strongUnsupportedEvidenceCount()
+	if strongEvidenceCount > 0 {
+		return "UNSUPPORTED: client-check code evidence remains"
+	}
+	if diagnosis.hasPatchedClientCheckSignature() && diagnosis.highRiskClientCheckDiagnosticCount() > 0 {
+		return "WARNING: high risk of client-check remaining after known patch"
+	}
+	if diagnosis.hasPatchedClientCheckSignature() && diagnosis.suspiciousActiveEvidenceCount() > 0 {
+		return "WARNING: known client-check patch applied but suspicious branch/call evidence remains"
+	}
+
+	coverage := diagnosis.knownPatchCoverage()
+	patchableCount := patchableBattleyePatchCount()
+	if coverage < patchableCount {
+		return "PARTIAL: only some known patchable signatures are covered"
+	}
+
+	return "SUPPORTED: all known patchable signatures are covered and no strong client-check evidence remains"
+}
+
+func (diagnosis diagnosisReport) knownPatchCoverage() int {
+	count := 0
+	for _, status := range diagnosis.patchStatuses {
+		if status.patch.diagnosticOnly {
+			continue
+		}
+		if len(status.originalOffset) > 0 || len(status.patchedOffset) > 0 {
+			count++
+		}
+	}
+	return count
+}
+
+func (diagnosis diagnosisReport) originalPatchSignatureCount() int {
+	count := 0
+	for _, status := range diagnosis.patchStatuses {
+		if status.patch.diagnosticOnly {
+			continue
+		}
+		if len(status.originalOffset) > 0 {
+			count++
+		}
+	}
+	return count
+}
+
+func (diagnosis diagnosisReport) patchedPatchSignatureCount() int {
+	count := 0
+	for _, status := range diagnosis.patchStatuses {
+		if status.patch.diagnosticOnly {
+			continue
+		}
+		if len(status.patchedOffset) > 0 {
+			count++
+		}
+	}
+	return count
+}
+
+func (diagnosis diagnosisReport) hasPatchedClientCheckSignature() bool {
+	return diagnosis.patchedPatchSignatureCount() > 0
+}
+
+func (diagnosis diagnosisReport) highRiskClientCheckDiagnosticCount() int {
+	count := 0
+	for _, status := range diagnosis.patchStatuses {
+		if !status.patch.diagnosticOnly || !status.patch.highRiskClientCheck {
+			continue
+		}
+		if len(status.originalOffset) > 0 || len(status.patchedOffset) > 0 {
+			count++
+		}
+	}
+	return count
+}
+
+func (diagnosis diagnosisReport) strongUnsupportedEvidenceCount() int {
+	count := 0
+	for _, finding := range diagnosis.clientCheckFindings {
+		for _, reference := range finding.references {
+			if reference.strongUnsupported {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func (diagnosis diagnosisReport) suspiciousActiveEvidenceCount() int {
+	count := 0
+	for _, finding := range diagnosis.clientCheckFindings {
+		for _, reference := range finding.references {
+			if reference.suspiciousActive {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func (diagnosis diagnosisReport) clientCheckIndicatorCount() int {
+	count := 0
+	for _, finding := range diagnosis.clientCheckFindings {
+		count += len(finding.offsets)
+	}
+	return count
+}
+
+func (diagnosis diagnosisReport) clientCheckCodeReferenceCount() int {
+	count := 0
+	for _, finding := range diagnosis.clientCheckFindings {
+		count += len(finding.references)
+	}
+	return count
+}
+
+func (diagnosis diagnosisReport) clientCheckIndicatorKeys() []string {
+	keys := make([]string, 0)
+	for _, finding := range diagnosis.clientCheckFindings {
+		keys = append(keys, fmt.Sprintf("%s/%s", finding.name, finding.encoding))
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func (diagnosis diagnosisReport) strongUnsupportedEvidenceKeys() []string {
+	keys := make([]string, 0)
+	for _, finding := range diagnosis.clientCheckFindings {
+		for _, reference := range finding.references {
+			if !reference.strongUnsupported {
+				continue
+			}
+			keys = append(keys, fmt.Sprintf("%s/%s ref=0x%X branches=%s calls=%s",
+				finding.name,
+				finding.encoding,
+				reference.offset,
+				formatOffsetsLimited(reference.branchOffsets, 3),
+				formatOffsetsLimited(reference.callOffsets, 3),
+			))
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func (diagnosis diagnosisReport) suspiciousActiveEvidenceKeys() []string {
+	keys := make([]string, 0)
+	for _, finding := range diagnosis.clientCheckFindings {
+		for _, reference := range finding.references {
+			if !reference.suspiciousActive {
+				continue
+			}
+			keys = append(keys, fmt.Sprintf("%s/%s ref=0x%X branches=%s calls=%s",
+				finding.name,
+				finding.encoding,
+				reference.offset,
+				formatNearestOffsets(reference.offset, reference.branchOffsets, 3),
+				formatNearestOffsets(reference.offset, reference.callOffsets, 3),
+			))
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func (diagnosis diagnosisReport) suspiciousActiveIndicatorKeys() []string {
+	keySet := make(map[string]struct{})
+	for _, finding := range diagnosis.clientCheckFindings {
+		for _, reference := range finding.references {
+			if !reference.suspiciousActive {
+				continue
+			}
+			keySet[fmt.Sprintf("%s/%s", finding.name, finding.encoding)] = struct{}{}
+		}
+	}
+
+	keys := make([]string, 0, len(keySet))
+	for key := range keySet {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func (diagnosis diagnosisReport) patchStateByName(name string) string {
+	for _, status := range diagnosis.patchStatuses {
+		if status.patch.name != name {
+			continue
+		}
+
+		switch {
+		case len(status.originalOffset) > 0 && len(status.patchedOffset) > 0:
+			return fmt.Sprintf("mixed original=%s patched=%s", formatOffsetsLimited(status.originalOffset, 4), formatOffsetsLimited(status.patchedOffset, 4))
+		case len(status.originalOffset) > 0:
+			return "original at " + formatOffsetsLimited(status.originalOffset, 4)
+		case len(status.patchedOffset) > 0:
+			return "patched at " + formatOffsetsLimited(status.patchedOffset, 4)
+		default:
+			return "absent"
+		}
+	}
+	return "unknown"
+}
+
+func findAllOffsets(data []byte, needle []byte) []int {
+	offsets := make([]int, 0)
+	if len(needle) == 0 || len(data) < len(needle) {
+		return offsets
+	}
+
+	searchOffset := 0
+	for searchOffset <= len(data)-len(needle) {
+		index := bytes.Index(data[searchOffset:], needle)
+		if index == -1 {
+			break
+		}
+
+		offset := searchOffset + index
+		offsets = append(offsets, offset)
+		searchOffset = offset + len(needle)
+	}
+	return offsets
+}
+
+func formatOffsets(offsets []int) string {
+	return formatOffsetsLimited(offsets, 0)
+}
+
+func formatOffsetsLimited(offsets []int, limit int) string {
+	if len(offsets) == 0 {
+		return "none"
+	}
+
+	displayOffsets := offsets
+	truncated := 0
+	if limit > 0 && len(offsets) > limit {
+		displayOffsets = offsets[:limit]
+		truncated = len(offsets) - limit
+	}
+
+	formatted := make([]string, 0, len(displayOffsets))
+	for _, offset := range displayOffsets {
+		formatted = append(formatted, fmt.Sprintf("0x%X", offset))
+	}
+	if truncated > 0 {
+		formatted = append(formatted, fmt.Sprintf("... +%d more", truncated))
+	}
+	return strings.Join(formatted, ", ")
+}
+
+func formatNearestOffsets(anchor int, offsets []int, limit int) string {
+	if len(offsets) == 0 {
+		return "none"
+	}
+
+	displayOffsets := append([]int(nil), offsets...)
+	sort.SliceStable(displayOffsets, func(left int, right int) bool {
+		leftDistance := absDistance(anchor, displayOffsets[left])
+		rightDistance := absDistance(anchor, displayOffsets[right])
+		if leftDistance == rightDistance {
+			return displayOffsets[left] < displayOffsets[right]
+		}
+		return leftDistance < rightDistance
+	})
+
+	truncated := 0
+	if limit > 0 && len(displayOffsets) > limit {
+		truncated = len(displayOffsets) - limit
+		displayOffsets = displayOffsets[:limit]
+	}
+
+	formatted := make([]string, 0, len(displayOffsets)+1)
+	for _, offset := range displayOffsets {
+		delta := offset - anchor
+		if delta >= 0 {
+			formatted = append(formatted, fmt.Sprintf("0x%X(+0x%X)", offset, delta))
+			continue
+		}
+		formatted = append(formatted, fmt.Sprintf("0x%X(-0x%X)", offset, -delta))
+	}
+	if truncated > 0 {
+		formatted = append(formatted, fmt.Sprintf("... +%d more", truncated))
+	}
+	return strings.Join(formatted, ", ")
+}
+
+func formatPatternMatches(matches []patternMatch, limit int) string {
+	if len(matches) == 0 {
+		return "none"
+	}
+
+	displayMatches := matches
+	truncated := 0
+	if limit > 0 && len(matches) > limit {
+		displayMatches = matches[:limit]
+		truncated = len(matches) - limit
+	}
+
+	formatted := make([]string, 0, len(displayMatches))
+	for _, match := range displayMatches {
+		formatted = append(formatted, fmt.Sprintf("%s@0x%X", match.name, match.offset))
+	}
+	if truncated > 0 {
+		formatted = append(formatted, fmt.Sprintf("... +%d more", truncated))
+	}
+	return strings.Join(formatted, ", ")
+}
+
+func bytesAround(data []byte, center int, radius int) (int, []byte) {
+	if len(data) == 0 || center < 0 || center >= len(data) {
+		return 0, nil
+	}
+
+	start := center - radius
+	if start < 0 {
+		start = 0
+	}
+	end := center + radius
+	if end > len(data) {
+		end = len(data)
+	}
+
+	return start, append([]byte(nil), data[start:end]...)
+}
+
+func bytesAroundRange(data []byte, start int, length int, radius int) (int, []byte) {
+	if len(data) == 0 || start < 0 || start >= len(data) || length <= 0 {
+		return 0, nil
+	}
+
+	end := start + length
+	if end > len(data) {
+		end = len(data)
+	}
+
+	contextStart := start - radius
+	if contextStart < 0 {
+		contextStart = 0
+	}
+	contextEnd := end + radius
+	if contextEnd > len(data) {
+		contextEnd = len(data)
+	}
+
+	return contextStart, append([]byte(nil), data[contextStart:contextEnd]...)
+}
+
+func formatBytes(data []byte) string {
+	if len(data) == 0 {
+		return "none"
+	}
+	return fmt.Sprintf("% X", data)
+}
+
+func formatPossibleInstructions(reference clientCheckReference) string {
+	if len(reference.contextBytes) == 0 {
+		return "none"
+	}
+
+	instructions := make([]string, 0)
+	for index := 0; index < len(reference.contextBytes); index++ {
+		offset := reference.contextStart + index
+		data := reference.contextBytes[index:]
+
+		if len(data) >= 7 && data[0] == 0x48 && data[1] == 0x8d && (data[2] == 0x15 || data[2] == 0x0d) {
+			registerName := "rdx"
+			if data[2] == 0x0d {
+				registerName = "rcx"
+			}
+			displacement := int(int32(binary.LittleEndian.Uint32(data[3:7])))
+			target := offset + 7 + displacement
+			instructions = append(instructions, fmt.Sprintf("0x%X: lea %s,[rip%+d] -> 0x%X", offset, registerName, displacement, target))
+			index += 6
+			continue
+		}
+		if len(data) >= 4 && data[0] == 0x48 && data[1] == 0x8d && data[2] == 0x4d {
+			instructions = append(instructions, fmt.Sprintf("0x%X: lea rcx,[rbp%+d]", offset, int(int8(data[3]))))
+			index += 3
+			continue
+		}
+		if len(data) >= 6 && data[0] == 0x41 && data[1] == 0xb8 {
+			immediate := binary.LittleEndian.Uint32(data[2:6])
+			instructions = append(instructions, fmt.Sprintf("0x%X: mov r8d,0x%X", offset, immediate))
+			index += 5
+			continue
+		}
+		if len(data) >= 5 && data[0] == 0xe8 {
+			displacement := int(int32(binary.LittleEndian.Uint32(data[1:5])))
+			target := offset + 5 + displacement
+			instructions = append(instructions, fmt.Sprintf("0x%X: call rel32 -> 0x%X", offset, target))
+			index += 4
+			continue
+		}
+		if len(data) >= 6 && data[0] == 0xff && data[1] == 0x15 {
+			displacement := int(int32(binary.LittleEndian.Uint32(data[2:6])))
+			target := offset + 6 + displacement
+			instructions = append(instructions, fmt.Sprintf("0x%X: call qword [rip%+d] -> 0x%X", offset, displacement, target))
+			index += 5
+			continue
+		}
+		if len(data) >= 5 && data[0] == 0xe9 {
+			displacement := int(int32(binary.LittleEndian.Uint32(data[1:5])))
+			target := offset + 5 + displacement
+			instructions = append(instructions, fmt.Sprintf("0x%X: jmp rel32 -> 0x%X", offset, target))
+			index += 4
+			continue
+		}
+		if len(data) >= 2 && data[0] == 0xeb {
+			target := offset + 2 + int(int8(data[1]))
+			instructions = append(instructions, fmt.Sprintf("0x%X: jmp short -> 0x%X", offset, target))
+			index += 1
+			continue
+		}
+		if isConditionalJump(reference.contextBytes, index, len(reference.contextBytes)) {
+			if data[0] >= 0x70 && data[0] <= 0x7f && len(data) >= 2 {
+				target := offset + 2 + int(int8(data[1]))
+				instructions = append(instructions, fmt.Sprintf("0x%X: jcc short 0x%02X -> 0x%X", offset, data[0], target))
+				index += 1
+				continue
+			}
+			if len(data) >= 6 && data[0] == 0x0f {
+				displacement := int(int32(binary.LittleEndian.Uint32(data[2:6])))
+				target := offset + 6 + displacement
+				instructions = append(instructions, fmt.Sprintf("0x%X: jcc near 0x%02X -> 0x%X", offset, data[1], target))
+				index += 5
+				continue
+			}
+		}
+		if len(data) >= 4 && data[0] == 0x48 && data[1] == 0x83 && (data[2] == 0xec || data[2] == 0xc4) {
+			operation := "sub"
+			if data[2] == 0xc4 {
+				operation = "add"
+			}
+			instructions = append(instructions, fmt.Sprintf("0x%X: %s rsp,0x%X", offset, operation, data[3]))
+			index += 3
+			continue
+		}
+	}
+
+	if len(instructions) == 0 {
+		return "none"
+	}
+	if len(instructions) > 10 {
+		return strings.Join(instructions[:10], "; ") + fmt.Sprintf("; ... +%d more", len(instructions)-10)
+	}
+	return strings.Join(instructions, "; ")
+}
+
+func newBytePattern(name string, values ...int) bytePattern {
+	pattern := bytePattern{
+		name: name,
+		data: make([]byte, len(values)),
+		mask: make([]bool, len(values)),
+	}
+
+	for index, value := range values {
+		if value == wildcardByte {
+			continue
+		}
+		if value < 0 || value > 0xff {
+			panic(fmt.Sprintf("invalid byte pattern value %d in %s", value, name))
+		}
+		pattern.data[index] = byte(value)
+		pattern.mask[index] = true
+	}
+
+	return pattern
+}
+
+func (pattern bytePattern) formatAOB() string {
+	if len(pattern.data) == 0 {
+		return "none"
+	}
+
+	parts := make([]string, 0, len(pattern.data))
+	for index, value := range pattern.data {
+		if !pattern.mask[index] {
+			parts = append(parts, "??")
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%02X", value))
+	}
+	return strings.Join(parts, " ")
+}
+
+func newPatchReplacement(values ...int) []int {
+	replacement := make([]int, len(values))
+	for index, value := range values {
+		if value == wildcardByte {
+			replacement[index] = wildcardByte
+			continue
+		}
+		if value < 0 || value > 0xff {
+			panic(fmt.Sprintf("invalid patch replacement value %d", value))
+		}
+		replacement[index] = value
+	}
+	return replacement
+}
+
+func applyBattleyePatch(tibiaBinary []byte, patch battleyePatch, offsets []int) []byte {
+	if patch.diagnosticOnly {
+		return tibiaBinary
+	}
+	if len(patch.replacement) != len(patch.original.data) {
+		fmt.Printf("[ERROR] Invalid BattlEye patch %q: replacement length differs from signature length\n", patch.name)
+		os.Exit(1)
+	}
+
+	for _, offset := range offsets {
+		contextStart, beforeBytes := bytesAroundRange(tibiaBinary, offset, len(patch.replacement), patchContextRadius)
+		for index, value := range patch.replacement {
+			if value == wildcardByte {
+				continue
+			}
+			tibiaBinary[offset+index] = byte(value)
+		}
+		_, afterBytes := bytesAroundRange(tibiaBinary, offset, len(patch.replacement), patchContextRadius)
+		contextEnd := contextStart + len(beforeBytes)
+		fmt.Printf("[INFO]   bytes before @0x%X..0x%X: %s\n", contextStart, contextEnd, formatBytes(beforeBytes))
+		fmt.Printf("[INFO]   bytes after  @0x%X..0x%X: %s\n", contextStart, contextEnd, formatBytes(afterBytes))
+	}
+	return tibiaBinary
+}
+
+func patchableBattleyePatchCount() int {
+	count := 0
+	for _, patch := range battleyePatches {
+		if !patch.diagnosticOnly {
+			count++
+		}
+	}
+	return count
+}
+
+func (patch battleyePatch) withAggressiveMode(aggressive bool) battleyePatch {
+	if !aggressive || len(patch.aggressiveReplacement) == 0 {
+		return patch
+	}
+
+	if len(patch.aggressiveReplacement) != len(patch.original.data) {
+		fmt.Printf("[ERROR] Invalid aggressive replacement for signature %q: replacement length differs from signature length\n", patch.name)
+		os.Exit(1)
+	}
+
+	patch.replacement = append([]int(nil), patch.aggressiveReplacement...)
+	patch.patched = newBytePattern(patch.name+" [aggressive]", patch.aggressiveReplacement...)
+
+	return patch
+}
+
+func (pattern bytePattern) findAll(data []byte) []int {
+	offsets := make([]int, 0)
+	if len(pattern.data) == 0 || len(data) < len(pattern.data) {
+		return offsets
+	}
+
+	for offset := 0; offset <= len(data)-len(pattern.data); offset++ {
+		if pattern.matchesAt(data, offset) {
+			offsets = append(offsets, offset)
+		}
+	}
+	return offsets
+}
+
+func (pattern bytePattern) matchesAt(data []byte, offset int) bool {
+	if offset < 0 || offset+len(pattern.data) > len(data) {
+		return false
+	}
+
+	for index := range pattern.data {
+		if pattern.mask[index] && data[offset+index] != pattern.data[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func (patch battleyePatch) expectedOffsetHits(data []byte, sha256Text string) []knownPatchOffset {
+	hits := make([]knownPatchOffset, 0)
+	for _, expected := range patch.expectedOffsets {
+		if !expected.appliesToSHA256(sha256Text) {
+			continue
+		}
+		if patch.matchesAtExpectedOffset(data, expected.offset) {
+			hits = append(hits, expected)
+		}
+	}
+	return hits
+}
+
+func (patch battleyePatch) expectedOffsetMisses(data []byte, sha256Text string) []knownPatchOffset {
+	misses := make([]knownPatchOffset, 0)
+	for _, expected := range patch.expectedOffsets {
+		if !expected.appliesToSHA256(sha256Text) {
+			continue
+		}
+		if !patch.matchesAtExpectedOffset(data, expected.offset) {
+			misses = append(misses, expected)
+		}
+	}
+	return misses
+}
+
+func (patch battleyePatch) matchesAtExpectedOffset(data []byte, offset int) bool {
+	return patch.original.matchesAt(data, offset) || patch.patched.matchesAt(data, offset)
+}
+
+func (expected knownPatchOffset) appliesToSHA256(sha256Text string) bool {
+	return expected.sha256 == "" || strings.EqualFold(expected.sha256, sha256Text)
+}
+
+func (peData peInfo) rvaForOffset(offset int) (int, bool) {
+	for _, section := range peData.sections {
+		if offset >= section.rawStart && offset < section.rawEnd {
+			return section.rvaStart + offset - section.rawStart, true
+		}
+	}
+	return 0, false
+}
+
+func utf16LEBytes(value string) []byte {
+	if value == "" {
+		return nil
+	}
+
+	encoded := make([]byte, 0, len(value)*2)
+	for _, char := range value {
+		if char > 0xffff {
+			continue
+		}
+		encoded = append(encoded, byte(char), byte(char>>8))
+	}
+	return encoded
+}
+
+func hasClientCheckStringIndicators(tibiaBinary []byte) bool {
+	for _, indicator := range clientCheckIndicators {
+		if bytes.Contains(tibiaBinary, indicator.value) || bytes.Contains(tibiaBinary, utf16LEBytes(string(indicator.value))) {
 			return true
 		}
 	}
 	return false
+}
+
+func differenceStrings(left []string, right []string) []string {
+	rightSet := make(map[string]struct{}, len(right))
+	for _, value := range right {
+		rightSet[value] = struct{}{}
+	}
+
+	difference := make([]string, 0)
+	for _, value := range left {
+		if _, ok := rightSet[value]; !ok {
+			difference = append(difference, value)
+		}
+	}
+	sort.Strings(difference)
+	return difference
+}
+
+func absDistance(left int, right int) int {
+	distance := left - right
+	if distance < 0 {
+		return -distance
+	}
+	return distance
 }
 
 func exportModifiedFile(tibiaPath string, tibiaBinary []byte, originalBinarySize int) {
@@ -216,6 +1911,51 @@ func readFile(filePath string) (string, []byte) {
 	}
 
 	return filePath, fileData
+}
+
+func resolveSourceExecutable(tibiaExe string, sourceTibiaExe string) string {
+	if sourceTibiaExe != "" {
+		return sourceTibiaExe
+	}
+
+	defaultSource := filepath.Join(filepath.Dir(tibiaExe), "client - original.exe")
+	if clean(defaultSource) == clean(tibiaExe) {
+		return clean(tibiaExe)
+	}
+
+	if _, err := os.Stat(defaultSource); err == nil {
+		return defaultSource
+	}
+
+	return tibiaExe
+}
+
+func clean(path string) string {
+	return filepath.Clean(path)
+}
+
+func neutralizeBranchJumpPattern(pattern bytePattern, patch map[int]int) []int {
+	replacement := make([]int, len(pattern.data))
+	for index := range replacement {
+		if index >= len(pattern.mask) || !pattern.mask[index] {
+			replacement[index] = wildcardByte
+			continue
+		}
+		replacement[index] = int(pattern.data[index])
+	}
+
+	for index, value := range patch {
+		if index < 0 || index >= len(replacement) {
+			fmt.Printf("[ERROR] Invalid branch neutralization offset %d for pattern %d bytes\n", index, len(replacement))
+			os.Exit(1)
+		}
+		if value < 0 || value > 0xff {
+			fmt.Printf("[ERROR] Invalid branch neutralization byte %d at position %d\n", value, index)
+			os.Exit(1)
+		}
+		replacement[index] = value
+	}
+	return replacement
 }
 
 func setPropertyByName(tibiaBinary []byte, propertyName string, customValue string) bool {

--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -2,6 +2,7 @@ package edit
 
 import (
 	"bytes"
+	"encoding/binary"
 	"testing"
 )
 
@@ -58,6 +59,85 @@ func TestRemoveBattlEyeSkipsMZWithoutPESignature(t *testing.T) {
 	}
 }
 
+func TestBytePatternFindAllSupportsWildcards(t *testing.T) {
+	pattern := newBytePattern("test", 0x75, wildcardByte, 0xe8, wildcardByte, wildcardByte, wildcardByte, wildcardByte)
+	offsets := pattern.findAll([]byte{0x90, 0x75, 0x04, 0xe8, 0x01, 0x02, 0x03, 0x04, 0x90})
+
+	if len(offsets) != 1 || offsets[0] != 1 {
+		t.Fatalf("expected wildcard pattern at offset 1, got %v", offsets)
+	}
+}
+
+func TestClientCheckStrongUnsupportedEvidenceRequiresUnknownCodeContext(t *testing.T) {
+	tibiaBinary, peData, referenceOffset := newClientCheckReferenceFixture("clientcheck_disconnected")
+
+	findings := scanClientCheckFindings(tibiaBinary, peData, nil)
+	diagnosis := diagnosisReport{clientCheckFindings: findings}
+
+	if diagnosis.strongUnsupportedEvidenceCount() != 1 {
+		t.Fatalf("expected one strong unsupported client-check evidence, got %d", diagnosis.strongUnsupportedEvidenceCount())
+	}
+
+	patchStatuses := []battleyePatchStatus{
+		{patch: battleyePatches[0], originalOffset: []int{referenceOffset + 8}},
+	}
+	findings = scanClientCheckFindings(tibiaBinary, peData, patchStatuses)
+	diagnosis = diagnosisReport{clientCheckFindings: findings}
+
+	if diagnosis.strongUnsupportedEvidenceCount() != 0 {
+		t.Fatalf("expected known nearby patch signature to suppress unsupported evidence, got %d", diagnosis.strongUnsupportedEvidenceCount())
+	}
+}
+
+func TestBEClientReferenceIsWeakIndicator(t *testing.T) {
+	tibiaBinary, peData, _ := newClientCheckReferenceFixture("BEClient")
+
+	findings := scanClientCheckFindings(tibiaBinary, peData, nil)
+	diagnosis := diagnosisReport{clientCheckFindings: findings}
+
+	if diagnosis.strongUnsupportedEvidenceCount() != 0 {
+		t.Fatalf("expected BEClient to remain weak, got %d strong evidence item(s)", diagnosis.strongUnsupportedEvidenceCount())
+	}
+}
+
+func TestSuspiciousActiveEvidenceRequiresPatchedSignatureForWarningVerdict(t *testing.T) {
+	tibiaBinary, peData, _ := newClientCheckReferenceFixtureWithoutRecognizedPattern("clientcheck_disconnected")
+
+	findings := scanClientCheckFindings(tibiaBinary, peData, nil)
+	diagnosis := diagnosisReport{
+		patchStatuses:       []battleyePatchStatus{{patch: battleyePatches[1], originalOffset: []int{0x180}}},
+		clientCheckFindings: findings,
+	}
+
+	if diagnosis.strongUnsupportedEvidenceCount() != 0 {
+		t.Fatalf("expected no strong unsupported evidence, got %d", diagnosis.strongUnsupportedEvidenceCount())
+	}
+	if diagnosis.suspiciousActiveEvidenceCount() != 1 {
+		t.Fatalf("expected one suspicious active evidence item, got %d", diagnosis.suspiciousActiveEvidenceCount())
+	}
+	if diagnosis.clientCheckVerdict() != "PARTIAL: only some known patchable signatures are covered" {
+		t.Fatalf("expected unpatched known signature to remain PARTIAL, got %q", diagnosis.clientCheckVerdict())
+	}
+
+	diagnosis.patchStatuses = []battleyePatchStatus{{patch: battleyePatches[1], patchedOffset: []int{0x180}}}
+	if diagnosis.clientCheckVerdict() != "WARNING: known client-check patch applied but suspicious branch/call evidence remains" {
+		t.Fatalf("expected patched known signature plus suspicious evidence to become WARNING, got %q", diagnosis.clientCheckVerdict())
+	}
+}
+
+func TestHighRiskDiagnosticSignatureChangesPatchedVerdict(t *testing.T) {
+	diagnosis := diagnosisReport{
+		patchStatuses: []battleyePatchStatus{
+			{patch: battleyePatches[1], patchedOffset: []int{0x2DE804}},
+			{patch: battleyePatch{name: "test high-risk", diagnosticOnly: true, highRiskClientCheck: true}, originalOffset: []int{0x1A8E3D}},
+		},
+	}
+
+	if diagnosis.clientCheckVerdict() != "WARNING: high risk of client-check remaining after known patch" {
+		t.Fatalf("expected high-risk diagnostic signature to change verdict, got %q", diagnosis.clientCheckVerdict())
+	}
+}
+
 func newPEBinary() []byte {
 	binary := make([]byte, 0x84)
 	binary[0] = 'M'
@@ -66,4 +146,53 @@ func newPEBinary() []byte {
 	binary[0x80] = 'P'
 	binary[0x81] = 'E'
 	return binary
+}
+
+func newClientCheckReferenceFixture(indicator string) ([]byte, peInfo, int) {
+	tibiaBinary := make([]byte, 0x420)
+	copy(tibiaBinary[0x300:], []byte(indicator))
+
+	peData := peInfo{
+		valid: true,
+		sections: []peSectionInfo{
+			{name: ".text", rawStart: 0x100, rawEnd: 0x200, rvaStart: 0x1000, rvaEnd: 0x1100, isCode: true},
+			{name: ".rdata", rawStart: 0x300, rawEnd: 0x420, rvaStart: 0x2000, rvaEnd: 0x2120},
+		},
+	}
+
+	referenceOffset := 0x120
+	referenceRVA := 0x1000 + referenceOffset - 0x100
+	stringRVA := 0x2000
+	displacement := int32(stringRVA - (referenceRVA + 7))
+
+	tibiaBinary[referenceOffset] = 0x48
+	tibiaBinary[referenceOffset+1] = 0x8d
+	tibiaBinary[referenceOffset+2] = 0x0d
+	binary.LittleEndian.PutUint32(tibiaBinary[referenceOffset+3:referenceOffset+7], uint32(displacement))
+	tibiaBinary[referenceOffset+8] = 0x75
+	tibiaBinary[referenceOffset+9] = 0x05
+	tibiaBinary[referenceOffset+10] = 0xe8
+	tibiaBinary[referenceOffset+11] = 0x01
+	tibiaBinary[referenceOffset+12] = 0x02
+	tibiaBinary[referenceOffset+13] = 0x03
+	tibiaBinary[referenceOffset+14] = 0x04
+
+	return tibiaBinary, peData, referenceOffset
+}
+
+func newClientCheckReferenceFixtureWithoutRecognizedPattern(indicator string) ([]byte, peInfo, int) {
+	tibiaBinary, peData, referenceOffset := newClientCheckReferenceFixture(indicator)
+	for index := referenceOffset + 8; index <= referenceOffset+14; index++ {
+		tibiaBinary[index] = 0x90
+	}
+
+	tibiaBinary[referenceOffset+0x20] = 0x75
+	tibiaBinary[referenceOffset+0x21] = 0x05
+	tibiaBinary[referenceOffset+0x40] = 0xe8
+	tibiaBinary[referenceOffset+0x41] = 0x01
+	tibiaBinary[referenceOffset+0x42] = 0x02
+	tibiaBinary[referenceOffset+0x43] = 0x03
+	tibiaBinary[referenceOffset+0x44] = 0x04
+
+	return tibiaBinary, peData, referenceOffset
 }

--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -13,7 +13,7 @@ func TestRemoveBattlEyeAppliesAllKnownWindowsPatches(t *testing.T) {
 	tibiaBinary = append(tibiaBinary, []byte{0x75, 0x0f, 0xe8, 0xd9, 0xd4, 0xed, 0xff, 0x48}...)
 	tibiaBinary = append(tibiaBinary, []byte{0x75, 0x0f, 0xe8, 0x35, 0xff, 0xff, 0xff, 0x48}...)
 
-	patched := removeBattlEye("client.exe", tibiaBinary)
+	patched := removeBattlEye("client.exe", tibiaBinary, false)
 
 	if bytes.Contains(patched, []byte{0x8d, 0x4d, 0xb4, 0x75, 0x0e, 0xe8, 0xb4, 0x53}) {
 		t.Fatal("expected legacy Battleye bytes to be patched")
@@ -40,7 +40,7 @@ func TestRemoveBattlEyeSkipsNonWindowsExecutable(t *testing.T) {
 	tibiaBinary = append(tibiaBinary, []byte{0x75, 0x0f, 0xe8, 0x35, 0xff, 0xff, 0xff, 0x48}...)
 	original := append([]byte(nil), tibiaBinary...)
 
-	patched := removeBattlEye("client.exe", tibiaBinary)
+	patched := removeBattlEye("client.exe", tibiaBinary, false)
 
 	if !bytes.Equal(patched, original) {
 		t.Fatal("expected non-Windows executable to be unchanged")
@@ -52,7 +52,7 @@ func TestRemoveBattlEyeSkipsMZWithoutPESignature(t *testing.T) {
 	tibiaBinary = append(tibiaBinary, []byte{0x75, 0x0f, 0xe8, 0x35, 0xff, 0xff, 0xff, 0x48}...)
 	original := append([]byte(nil), tibiaBinary...)
 
-	patched := removeBattlEye("client.exe", tibiaBinary)
+	patched := removeBattlEye("client.exe", tibiaBinary, false)
 
 	if !bytes.Equal(patched, original) {
 		t.Fatal("expected MZ-only executable to be unchanged")
@@ -136,6 +136,104 @@ func TestHighRiskDiagnosticSignatureChangesPatchedVerdict(t *testing.T) {
 	if diagnosis.clientCheckVerdict() != "WARNING: high risk of client-check remaining after known patch" {
 		t.Fatalf("expected high-risk diagnostic signature to change verdict, got %q", diagnosis.clientCheckVerdict())
 	}
+}
+
+func TestUpdateConfigINIContentSyncsWithEmbeddedClientConfig(t *testing.T) {
+	embeddedConfig := mustParseEmbeddedConfigINI(t, []byte("[URLS]\r\nloginWebService=http://127.0.0.1/login.php\r\nclientWebService=http://127.0.0.1/client.php\r\n[SOUND]\r\nfailInitialization=false\r\n"))
+	configData := []byte("; keep this comment\r\nunknownKey=keep\r\nloginWebService = old\r\n")
+
+	updated, changedCount, addedCount, removedCount, changed := updateConfigINIContent(configData, embeddedConfig)
+
+	expected := "; keep this comment\r\nunknownKey=keep\r\nloginWebService = old\r\n\r\n[URLS]\r\nloginWebService=http://127.0.0.1/login.php\r\nclientWebService=http://127.0.0.1/client.php\r\n\r\n[SOUND]\r\nfailInitialization=false\r\n"
+	if !changed {
+		t.Fatal("expected config.ini content to change")
+	}
+	if changedCount != 0 {
+		t.Fatalf("expected no managed section key updates, got %d", changedCount)
+	}
+	if addedCount != 3 {
+		t.Fatalf("expected three missing embedded keys to be appended, got %d", addedCount)
+	}
+	if removedCount != 0 {
+		t.Fatalf("expected no obsolete managed keys to be removed, got %d", removedCount)
+	}
+	if string(updated) != expected {
+		t.Fatalf("unexpected config.ini content:\n%s", string(updated))
+	}
+}
+
+func TestUpdateConfigINIContentKeepsUpToDateContentUnchanged(t *testing.T) {
+	embeddedConfig := mustParseEmbeddedConfigINI(t, []byte("[URLS]\nloginWebService=http://127.0.0.1/login.php\n"))
+	configData := []byte("[URLS]\nloginWebService=http://127.0.0.1/login.php\n[LOCAL]\nunknownKey=keep\n")
+
+	updated, changedCount, addedCount, removedCount, changed := updateConfigINIContent(configData, embeddedConfig)
+
+	if changed {
+		t.Fatal("expected up-to-date config.ini content to stay unchanged")
+	}
+	if changedCount != 0 || addedCount != 0 || removedCount != 0 {
+		t.Fatalf("expected zero changes, got changed=%d added=%d removed=%d", changedCount, addedCount, removedCount)
+	}
+	if !bytes.Equal(updated, configData) {
+		t.Fatal("expected original config.ini bytes to be preserved")
+	}
+}
+
+func TestUpdateConfigINIContentUpdatesAndRemovesManagedSectionKeys(t *testing.T) {
+	embeddedConfig := mustParseEmbeddedConfigINI(t, []byte("[URLS]\nloginWebService=http://127.0.0.1/login.php\nclientWebService=http://127.0.0.1/client.php\n"))
+	configData := []byte("[URLS]\nloginWebService=old\ncreateTournamentCharacterUrl=obsolete\n")
+
+	updated, changedCount, addedCount, removedCount, changed := updateConfigINIContent(configData, embeddedConfig)
+
+	expected := "[URLS]\nloginWebService=http://127.0.0.1/login.php\nclientWebService=http://127.0.0.1/client.php\n"
+	if !changed {
+		t.Fatal("expected managed config.ini section to be updated")
+	}
+	if changedCount != 1 {
+		t.Fatalf("expected one outdated value, got %d", changedCount)
+	}
+	if addedCount != 1 {
+		t.Fatalf("expected one new key, got %d", addedCount)
+	}
+	if removedCount != 1 {
+		t.Fatalf("expected one obsolete key to be removed, got %d", removedCount)
+	}
+	if string(updated) != expected {
+		t.Fatalf("unexpected config.ini content:\n%s", string(updated))
+	}
+}
+
+func TestUpdateConfigINIContentCreatesOrderedSectionsFromEmbeddedConfig(t *testing.T) {
+	embeddedConfig := mustParseEmbeddedConfigINI(t, []byte("[URLS]\nloginWebService=http://127.0.0.1/login.php\nclientWebService=http://127.0.0.1/client.php\n[SOUND]\nfailInitialization=false\n"))
+
+	updated, changedCount, addedCount, removedCount, changed := updateConfigINIContent(nil, embeddedConfig)
+
+	expected := "[URLS]\nloginWebService=http://127.0.0.1/login.php\nclientWebService=http://127.0.0.1/client.php\n\n[SOUND]\nfailInitialization=false\n"
+	if !changed {
+		t.Fatal("expected empty config.ini content to be created")
+	}
+	if changedCount != 0 {
+		t.Fatalf("expected no outdated values, got %d", changedCount)
+	}
+	if addedCount != 3 {
+		t.Fatalf("expected three new keys, got %d", addedCount)
+	}
+	if removedCount != 0 {
+		t.Fatalf("expected no obsolete keys, got %d", removedCount)
+	}
+	if string(updated) != expected {
+		t.Fatalf("unexpected config.ini content:\n%s", string(updated))
+	}
+}
+
+func mustParseEmbeddedConfigINI(t *testing.T, configData []byte) embeddedConfigINI {
+	t.Helper()
+
+	embeddedConfig, ok := parseEmbeddedConfigINI(configData)
+	if !ok {
+		t.Fatal("expected embedded config.ini block to parse")
+	}
+	return embeddedConfig
 }
 
 func newPEBinary() []byte {

--- a/main.go
+++ b/main.go
@@ -29,7 +29,8 @@ var rootCmd = &cobra.Command{
 	Use:   "client-editor",
 	Short: "Edit or repack Tibia client",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		if cmd.Name() == "diagnose" {
+		switch cmd.Name() {
+		case "diagnose", "repack", "win2mac":
 			return
 		}
 		if configFile != "" {
@@ -82,7 +83,7 @@ func init() {
 	editCmd.PersistentFlags().StringVarP(&tibiaExe, "tibia-exe", "t", getDefaultTibiaExe(), "Path to Tibia executable")
 	editCmd.PersistentFlags().StringVar(&sourceTibiaExe, "source-exe", "", "Optional pristine source executable to use as input; defaults to \"client - original.exe\" beside --tibia-exe when present")
 	editCmd.PersistentFlags().BoolVar(&aggressiveEditClientCheck, "aggressive", false, "Also rewrite high-risk client-check dispatch signatures (experimental; keep backup and manual verify)")
-	editCmd.PersistentFlags().BoolVar(&strictEditClientCheck, "strict", false, "Fail before export when client-check compatibility is partial or unsupported")
+	editCmd.PersistentFlags().BoolVar(&strictEditClientCheck, "strict", false, "Fail before export when client-check compatibility is partial, warning, or unsupported")
 	editCmd.PersistentFlags().BoolVar(&strictEditClientCheck, "fail-on-partial", false, "Alias for --strict")
 	editCmd.PersistentFlags().BoolVar(&strictEditClientCheck, "fail-on-unsupported-client-check", false, "Alias for --strict")
 	editCmd.PersistentFlags().BoolVar(&strictEditClientCheck, "fail-on-partial-client-check-patch", false, "Deprecated alias for --strict")
@@ -98,7 +99,7 @@ func init() {
 	}
 	diagnoseCmd.PersistentFlags().StringVarP(&tibiaExe, "tibia-exe", "t", getDefaultTibiaExe(), "Path to Tibia executable")
 	diagnoseCmd.PersistentFlags().StringVar(&compareTibiaExe, "compare-with", "", "Path to a known-good older Tibia executable for comparative diagnosis")
-	diagnoseCmd.PersistentFlags().BoolVar(&strictDiagnoseClientCheck, "strict", false, "Exit with an error when client-check compatibility is partial or unsupported")
+	diagnoseCmd.PersistentFlags().BoolVar(&strictDiagnoseClientCheck, "strict", false, "Exit with an error when client-check compatibility is partial, warning, or unsupported")
 	diagnoseCmd.PersistentFlags().BoolVar(&strictDiagnoseClientCheck, "fail-on-partial", false, "Alias for --strict")
 	diagnoseCmd.PersistentFlags().BoolVar(&strictDiagnoseClientCheck, "fail-on-unsupported-client-check", false, "Alias for --strict")
 	diagnoseCmd.PersistentFlags().BoolVar(&strictDiagnoseClientCheck, "fail-on-partial-client-check-patch", false, "Deprecated alias for --strict")

--- a/main.go
+++ b/main.go
@@ -18,12 +18,20 @@ var (
 	srcClient, dstClient                  string
 	srcFile, dstFile                      string
 	platform                              string
+	compareTibiaExe                       string
+	strictEditClientCheck                 bool
+	aggressiveEditClientCheck             bool
+	sourceTibiaExe                        string
+	strictDiagnoseClientCheck             bool
 )
 
 var rootCmd = &cobra.Command{
 	Use:   "client-editor",
 	Short: "Edit or repack Tibia client",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		if cmd.Name() == "diagnose" {
+			return
+		}
 		if configFile != "" {
 			viper.SetConfigFile(configFile)
 		}
@@ -68,11 +76,34 @@ func init() {
 		Use:   "edit",
 		Short: "Edit Tibia binary",
 		Run: func(cmd *cobra.Command, args []string) {
-			edit.Edit(tibiaExe)
+			edit.Edit(tibiaExe, sourceTibiaExe, strictEditClientCheck, aggressiveEditClientCheck)
 		},
 	}
 	editCmd.PersistentFlags().StringVarP(&tibiaExe, "tibia-exe", "t", getDefaultTibiaExe(), "Path to Tibia executable")
+	editCmd.PersistentFlags().StringVar(&sourceTibiaExe, "source-exe", "", "Optional pristine source executable to use as input; defaults to \"client - original.exe\" beside --tibia-exe when present")
+	editCmd.PersistentFlags().BoolVar(&aggressiveEditClientCheck, "aggressive", false, "Also rewrite high-risk client-check dispatch signatures (experimental; keep backup and manual verify)")
+	editCmd.PersistentFlags().BoolVar(&strictEditClientCheck, "strict", false, "Fail before export when client-check compatibility is partial or unsupported")
+	editCmd.PersistentFlags().BoolVar(&strictEditClientCheck, "fail-on-partial", false, "Alias for --strict")
+	editCmd.PersistentFlags().BoolVar(&strictEditClientCheck, "fail-on-unsupported-client-check", false, "Alias for --strict")
+	editCmd.PersistentFlags().BoolVar(&strictEditClientCheck, "fail-on-partial-client-check-patch", false, "Deprecated alias for --strict")
+	_ = editCmd.PersistentFlags().MarkDeprecated("fail-on-partial-client-check-patch", "use --strict")
 	rootCmd.AddCommand(editCmd)
+
+	diagnoseCmd := &cobra.Command{
+		Use:   "diagnose",
+		Short: "Diagnose Tibia binary patch compatibility",
+		Run: func(cmd *cobra.Command, args []string) {
+			edit.Diagnose(tibiaExe, compareTibiaExe, strictDiagnoseClientCheck)
+		},
+	}
+	diagnoseCmd.PersistentFlags().StringVarP(&tibiaExe, "tibia-exe", "t", getDefaultTibiaExe(), "Path to Tibia executable")
+	diagnoseCmd.PersistentFlags().StringVar(&compareTibiaExe, "compare-with", "", "Path to a known-good older Tibia executable for comparative diagnosis")
+	diagnoseCmd.PersistentFlags().BoolVar(&strictDiagnoseClientCheck, "strict", false, "Exit with an error when client-check compatibility is partial or unsupported")
+	diagnoseCmd.PersistentFlags().BoolVar(&strictDiagnoseClientCheck, "fail-on-partial", false, "Alias for --strict")
+	diagnoseCmd.PersistentFlags().BoolVar(&strictDiagnoseClientCheck, "fail-on-unsupported-client-check", false, "Alias for --strict")
+	diagnoseCmd.PersistentFlags().BoolVar(&strictDiagnoseClientCheck, "fail-on-partial-client-check-patch", false, "Deprecated alias for --strict")
+	_ = diagnoseCmd.PersistentFlags().MarkDeprecated("fail-on-partial-client-check-patch", "use --strict")
+	rootCmd.AddCommand(diagnoseCmd)
 
 	appearancesCmd := &cobra.Command{
 		Use:   "appearances",


### PR DESCRIPTION
## Summary

- Adds an experimental `--aggressive` mode for `edit` that can rewrite known high-risk BattlEye/client-check dispatch paths.
- Keeps the default edit flow safe: high-risk signatures remain diagnostic-only unless `--aggressive` is explicitly enabled.
- Adds `--strict`, `diagnose`, and `--source-exe` flows so risky or partial client-check support can be inspected and controlled.
- Logs before/after byte windows for every applied BattlEye/client-check patch and keeps an explicit timestamped backup before export.
- Updates README guidance for safe mode, aggressive mode, diagnostics, verdicts, and pristine source executable usage.

## Safety behavior

- `--aggressive=false` keeps high-risk signatures as warnings only.
- `--aggressive=true` makes the known high-risk signatures patchable for manually validated clients.
- `diagnose` continues to report high-risk paths as diagnostic evidence.
- `--strict` still blocks export for partial, warning, or unsupported client-check verdicts.

## Validation

- Re-applied `edit --aggressive` from a pristine 15.13 client and confirmed the BattlEye warning dialog was removed.
- Ran `diagnose` and `edit --aggressive` against a 15.20 client source; the 15.13 high-risk signatures did not false-match, and only the stable known patch was applied.
- Ran static cleanup checks for debug leftovers, local paths, temporary command artifacts, and whitespace issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `diagnose` command to inspect and analyze binaries with optional side-by-side comparison.
  * Added `--source-exe`, `--strict`, and `--aggressive` flags to provide more control over client-check patching.

* **Documentation**
  * Expanded documentation with new sections on client-check safety behavior and diagnose workflow.
  * Updated Windows examples with clearer placeholder paths.

* **Tests**
  * Added tests for byte-pattern matching and diagnostic verdict logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->